### PR TITLE
Paging level data

### DIFF
--- a/Source/SPUD/Private/SpudData.cpp
+++ b/Source/SPUD/Private/SpudData.cpp
@@ -140,7 +140,7 @@ void FSpudClassDef::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}	
 }
 
-void FSpudClassDef::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 DataVersion)
+void FSpudClassDef::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	if (ChunkStart(Ar))
 	{
@@ -231,11 +231,11 @@ void FSpudPropertyData::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	FSpudDataHolder::WriteToArchive(Ar);
 }
 
-void FSpudPropertyData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 DataVersion)
+void FSpudPropertyData::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	PropertyOffsets.Empty();
 	Ar << PropertyOffsets;
-	FSpudDataHolder::ReadFromArchive(Ar, DataVersion);
+	FSpudDataHolder::ReadFromArchive(Ar);
 }
 
 void FSpudPropertyData::Reset()
@@ -261,7 +261,7 @@ void FSpudDataHolder::WriteToArchive(FSpudChunkedDataArchive& Ar)
 		ChunkEnd(Ar);
 	}
 }
-void FSpudDataHolder::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 DataVersion)
+void FSpudDataHolder::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	if (ChunkStart(Ar))
 	{
@@ -286,7 +286,7 @@ void FSpudDestroyedLevelActor::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudDestroyedLevelActor::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 DataVersion)
+void FSpudDestroyedLevelActor::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	// Simple case
 	if (ChunkStart(Ar))
@@ -309,14 +309,14 @@ void FSpudNamedObjectData::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudNamedObjectData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 DataVersion)
+void FSpudNamedObjectData::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	if (ChunkStart(Ar))
 	{
 		Ar << Name;
-		CoreData.ReadFromArchive(Ar, DataVersion);
-		Properties.ReadFromArchive(Ar, DataVersion);
-		CustomData.ReadFromArchive(Ar, DataVersion);
+		CoreData.ReadFromArchive(Ar);
+		Properties.ReadFromArchive(Ar);
+		CustomData.ReadFromArchive(Ar);
 		ChunkEnd(Ar);
 	}
 }
@@ -334,15 +334,15 @@ void FSpudSpawnedActorData::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudSpawnedActorData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 DataVersion)
+void FSpudSpawnedActorData::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	if (ChunkStart(Ar))
 	{
 		Ar << ClassID;
 		Ar << Guid;
-		CoreData.ReadFromArchive(Ar, DataVersion);
-		Properties.ReadFromArchive(Ar, DataVersion);
-		CustomData.ReadFromArchive(Ar, DataVersion);
+		CoreData.ReadFromArchive(Ar);
+		Properties.ReadFromArchive(Ar);
+		CustomData.ReadFromArchive(Ar);
 		ChunkEnd(Ar);
 	}
 }
@@ -368,7 +368,7 @@ void FSpudClassMetadata::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudClassMetadata::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 Version)
+void FSpudClassMetadata::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	if (ChunkStart(Ar))
 	{
@@ -380,11 +380,11 @@ void FSpudClassMetadata::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 Ver
 		{
 			Ar.PreviewNextChunk(Hdr, true);
 			if (Hdr.Magic == ClassNameIndexID)
-				ClassNameIndex.ReadFromArchive(Ar, Version);
+				ClassNameIndex.ReadFromArchive(Ar);
 			else if (Hdr.Magic == ClassDefListID)
-				ClassDefinitions.ReadFromArchive(Ar, Version);
+				ClassDefinitions.ReadFromArchive(Ar);
 			else if (Hdr.Magic == PropertyNameIndexID)
-				PropertyNameIndex.ReadFromArchive(Ar, Version);
+				PropertyNameIndex.ReadFromArchive(Ar);
 			else
 				Ar.SkipNextChunk();
 		}
@@ -468,7 +468,7 @@ void FSpudLevelData::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudLevelData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 Version)
+void FSpudLevelData::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	// Separate loading process since it's easier to deal with chunk robustness and versions
 	if (ChunkStart(Ar))
@@ -484,13 +484,13 @@ void FSpudLevelData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 Version
 		{
 			Ar.PreviewNextChunk(Hdr, true);
 			if (Hdr.Magic == MetadataID)
-				Metadata.ReadFromArchive(Ar, Version);
+				Metadata.ReadFromArchive(Ar);
 			else if (Hdr.Magic == LevelActorsID)
-				LevelActors.ReadFromArchive(Ar, Version);
+				LevelActors.ReadFromArchive(Ar);
 			else if (Hdr.Magic == SpawnedActorsID)
-				SpawnedActors.ReadFromArchive(Ar, Version);
+				SpawnedActors.ReadFromArchive(Ar);
 			else if (Hdr.Magic == DestroyedActorsID)
-				DestroyedActors.ReadFromArchive(Ar, Version);
+				DestroyedActors.ReadFromArchive(Ar);
 			else
 				Ar.SkipNextChunk();
 		}
@@ -529,7 +529,7 @@ void FSpudGlobalData::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudGlobalData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 Version)
+void FSpudGlobalData::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	// Separate loading process since it's easier to deal with chunk robustness and versions
 	if (ChunkStart(Ar))
@@ -543,9 +543,9 @@ void FSpudGlobalData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 Versio
 		{
 			Ar.PreviewNextChunk(Hdr, true);
 			if (Hdr.Magic == MetadataID)
-				Metadata.ReadFromArchive(Ar, Version);
+				Metadata.ReadFromArchive(Ar);
 			else if (Hdr.Magic == ObjectsID)
-				Objects.ReadFromArchive(Ar, Version);
+				Objects.ReadFromArchive(Ar);
 			else
 				Ar.SkipNextChunk();
 		}
@@ -577,7 +577,7 @@ void FSpudSaveInfo::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudSaveInfo::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 IGNOREDDataVersion)
+void FSpudSaveInfo::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	if (ChunkStart(Ar))
 	{
@@ -615,7 +615,7 @@ void FSpudSaveData::WriteToArchive(FSpudChunkedDataArchive& Ar)
 	}
 }
 
-void FSpudSaveData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 IGNOREDDataVersion)
+void FSpudSaveData::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 {
 	if (ChunkStart(Ar))
 	{
@@ -631,7 +631,7 @@ void FSpudSaveData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 IGNOREDD
 			return;
 		}
 
-		Info.ReadFromArchive(Ar, IGNOREDDataVersion);
+		Info.ReadFromArchive(Ar);
 
 		if (Ar.IsLoading() && Info.Version != SPUD_SAVEGAME_CURRENT_VERSION)
 		{
@@ -643,11 +643,11 @@ void FSpudSaveData::ReadFromArchive(FSpudChunkedDataArchive& Ar, uint16 IGNOREDD
 		{
 			Ar.PreviewNextChunk(Hdr, true);
 			if (Hdr.Magic == GlobalDataID)
-				GlobalData.ReadFromArchive(Ar, Info.Version);
+				GlobalData.ReadFromArchive(Ar);
 			else if (Hdr.Magic == LevelDataMapID)
 			{
 				// Important: in this case we're reading from a combined save game, so all levels are present
-				LevelDataMap.ReadFromArchive(Ar, Info.Version);
+				LevelDataMap.ReadFromArchive(Ar);
 			}
 			else
 				Ar.SkipNextChunk();
@@ -680,7 +680,7 @@ bool FSpudSaveData::ReadSaveInfoFromArchive(FSpudChunkedDataArchive& Ar, FSpudSa
 		UE_LOG(LogSpudData, Error, TEXT("Cannot get info for save game, INFO chunk isn't present at start"))
 		return false;		
 	}
-	OutInfo.ReadFromArchive(Ar, 0);
+	OutInfo.ReadFromArchive(Ar);
 
 	return true;
 	

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -245,10 +245,6 @@ FSpudSpawnedActorData* USpudState::GetSpawnedActorData(AActor* Actor, FSpudLevel
 		UE_LOG(LogSpudState, Error, TEXT("Ignoring runtime actor %s, missing or blank SpudGuid property"), *Actor->GetName())
 		UE_LOG(LogSpudState, Error, TEXT("  Runtime spawned actors should have a SpudGuid property to identify them, initialised to valid unique value."))
 		UE_LOG(LogSpudState, Error, TEXT("  NOTE: If this actor is part of a level and not runtime spawned, the cause of this false detection might be that you haven't SAVED the level before playing in the editor."))
-
-		// TODO: if a class is a level object but happens to have a SpudGuid property anyway (maybe because sometimes runtime)
-		// the lack of a level save making it look like a runtime object cannot be detected. Can we *maybe* call editor code somehow
-		// to determine this?
 		return nullptr;			
 	}
 	

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -920,7 +920,7 @@ void USpudState::SaveToArchive(FArchive& Ar, const FText& Title)
 	FSpudChunkedDataArchive ChunkedAr(Ar);
 	SaveData.PrepareForWrite(Title);
 	// Use WritePaged in all cases; if all data is loaded it amounts to the same thing
-	SaveData.WritePagedToArchive(ChunkedAr, GetActiveGameLevelFolder());
+	SaveData.WriteToArchive(ChunkedAr, GetActiveGameLevelFolder());
 
 }
 
@@ -933,7 +933,7 @@ void USpudState::LoadFromArchive(FArchive& Ar, bool bFullyLoadAllLevelData)
 	if (bFullyLoadAllLevelData)
 		SaveData.ReadFromArchive(ChunkedAr);
 	else
-		SaveData.ReadPagedFromArchive(ChunkedAr, GetActiveGameLevelFolder());
+		SaveData.ReadFromArchive(ChunkedAr, false, GetActiveGameLevelFolder());
 }
 
 bool USpudState::LoadSaveInfoFromArchive(FArchive& Ar, USpudSaveGameInfo& OutInfo)

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -956,7 +956,7 @@ bool USpudState::LoadSaveInfoFromArchive(FArchive& Ar, USpudSaveGameInfo& OutInf
 
 FString USpudState::GetActiveGameLevelFolder()
 {
-	return FString::Printf(TEXT("%sActiveGameCache/"), *FPaths::ProjectSavedDir());	
+	return FString::Printf(TEXT("%sSpudCache/"), *FPaths::ProjectSavedDir());	
 }
 
 void USpudState::RemoveAllActiveGameLevelFiles()

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -402,6 +402,13 @@ void USpudState::RestoreLevel(ULevel* Level)
 
 }
 
+bool USpudState::PreLoadLevelData(const FString& LevelName)
+{
+	// Don't auto-create, but do load if needed
+	auto Data = GetLevelData(LevelName, false);
+	return Data != nullptr;
+}
+
 void USpudState::RestoreActor(AActor* Actor)
 {
 	if (Actor->HasAnyFlags(RF_ClassDefaultObject|RF_ArchetypeObject|RF_BeginDestroyed))

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -914,7 +914,7 @@ void USpudState::SaveToArchive(FArchive& Ar, const FText& Title)
 void USpudState::LoadFromArchive(FArchive& Ar)
 {
 	FSpudChunkedDataArchive ChunkedAr(Ar);
-	SaveData.ReadFromArchive(ChunkedAr, 0);	
+	SaveData.ReadFromArchive(ChunkedAr);	
 }
 
 bool USpudState::LoadSaveInfoFromArchive(FArchive& Ar, USpudSaveGameInfo& OutInfo)

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -483,7 +483,13 @@ void USpudSubsystem::PostLoadStreamLevelGameThread(FName LevelName)
 		// It's important to note that this streaming level won't be added to UWorld::Levels yet
 		// This is usually where things like the TActorIterator get actors from, ULevel::Actors
 		// we have the ULevel here right now, so restore it directly
-		GetActiveState()->RestoreLevel(Level);			
+		GetActiveState()->RestoreLevel(Level);
+
+		// NB: after restoring the level, we could release MOST of the memory for this level
+		// However, we don't for 2 reasons:
+		// 1. Destroyed actors for this level are logged continuously while running, so that still needs to be active
+		// 2. We can assume that we'll need to write data back to save when this level is unloaded. It's actually less
+		//    memory thrashing to re-use the same memory we have until unload, since it'll likely be almost identical in structure
 		StreamLevel->SetShouldBeVisible(true);
 		SubscribeLevelObjectEvents(Level);
 		PostLevelRestore.Broadcast(LevelName.ToString(), true);

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -445,6 +445,10 @@ void USpudSubsystem::PostLoadStreamLevel(int32 LinkID)
 		}		
 
 		// Defer the restore to the game thread, streaming calls happen in loading thread?
+		// However, quickly ping the state to force it to pre-load the leveldata
+		// that way the loading occurs in this thread, less latency
+		GetActiveState()->PreLoadLevelData(LevelName.ToString());			
+
 		AsyncTask(ENamedThreads::GameThread, [this, LevelName]()
         {
 			// But also add a slight delay so we get a tick in between so physics works

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -221,6 +221,10 @@ public:
 	/// Specialised function for restoring a specific level by reference
 	void RestoreLevel(ULevel* Level);
 
+	/// Request that data for a level is loaded in the calling thread
+	/// Useful for pre-caching before RestoreLevel
+	bool PreLoadLevelData(const FString& LevelName);
+
 	// Restores the world and all levels currently in it, on the assumption that it's already loaded into the correct map
 	void RestoreLoadedWorld(UWorld* World);
 

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -182,16 +182,6 @@ public:
 	/// Store the top-level information about the world, but none of the level contents
 	void StoreWorldGlobals(UWorld* World);
 
-
-	/**
-	* @brief Store the state of objects in the current world which are attached to a specific level.
-	* Only processes actors which implement ISpudObject.
-	* @param World The world pointer
-	* @param LevelName Name of the level
-	* @param bReleaseAfter If true, after storing the level data, it is removed from memory and stored on disk
-	*/
-	void StoreLevel(UWorld* World, const FString& LevelName, bool bReleaseAfter);
-
 	/**
 	 * @brief Store the state of objects in the current world which are attached to a specific level.
 	 * Only processes actors which implement ISpudObject.
@@ -269,6 +259,9 @@ public:
 
 	/// Get the name of the persistent level which the player is on in this state
 	FString GetPersistentLevel() const { return SaveData.GlobalData.CurrentLevel; }
+
+	/// Get whether the persistent data for a given level is in memory right now or not
+	bool IsLevelDataLoaded(const FString& LevelName);
 
 	/// Utility method to read *just* the information part of a save game from the start of an archive
 	/// This only reads the minimum needed to describe the save file and doesn't load any other data.

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -156,8 +156,8 @@ protected:
 	UFUNCTION(BlueprintCallable)
     void PostUnloadStreamLevelGameThread(FName LevelName);
 
-	void StoreWorld(UWorld* World);
-	void StoreLevel(ULevel* Level);
+	void StoreWorld(UWorld* World, bool bReleaseLevels);
+	void StoreLevel(ULevel* Level, bool bRelease);
 
 	void LoadComplete(const FString& SlotName, bool bSuccess);
 	void SaveComplete(const FString& SlotName, bool bSuccess);


### PR DESCRIPTION
Improve scalability by not loading all level data into memory at once, instead splitting it out on load into separate level state files which can be paged in / out as needed. When saving, both the in-memory data and any paged out level data is re-combined into a single self-contained save file, which contains the entire game state again.