### PR TITLE
Manual save upgrades

### DIFF
--- a/Source/SPUD/Private/SpudData.cpp
+++ b/Source/SPUD/Private/SpudData.cpp
@@ -691,11 +691,9 @@ void FSpudSaveInfo::ReadFromArchive(FSpudChunkedDataArchive& Ar)
 }
 
 //------------------------------------------------------------------------------
-void FSpudSaveData::PrepareForWrite(const FText& Title)
+void FSpudSaveData::PrepareForWrite()
 {
-	Info.Title = Title;
 	Info.SystemVersion = SPUD_CURRENT_SYSTEM_VERSION;
-	Info.Timestamp = FDateTime::Now();
 }
 
 void FSpudSaveData::WriteToArchive(FSpudChunkedDataArchive& Ar)

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -913,12 +913,12 @@ void USpudState::StoreLevelActorDestroyed(AActor* Actor, FSpudSaveData::TLevelDa
 	LevelData->DestroyedActors.Add(SpudPropertyUtil::GetLevelActorName(Actor));
 }
 
-void USpudState::SaveToArchive(FArchive& Ar, const FText& Title)
+void USpudState::SaveToArchive(FArchive& Ar)
 {
 	// We use separate read / write in order to more clearly support chunked file format
 	// with the backwards compatibility that comes with 
 	FSpudChunkedDataArchive ChunkedAr(Ar);
-	SaveData.PrepareForWrite(Title);
+	SaveData.PrepareForWrite();
 	// Use WritePaged in all cases; if all data is loaded it amounts to the same thing
 	SaveData.WriteToArchive(ChunkedAr, GetActiveGameLevelFolder());
 

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -1012,13 +1012,18 @@ bool USpudState::RenameProperty(const FString& ClassName, const FString& OldProp
 
 bool USpudState::RenameGlobalObject(const FString& OldName, const FString& NewName)
 {
-	// TODO
-	return false;
+	return SaveData.GlobalData.Objects.RenameObject(OldName, NewName);
 }
 
 bool USpudState::RenameLevelObject(const FString& LevelName, const FString& OldName, const FString& NewName)
 {
-	// TODO
+	auto LevelData = GetLevelData(LevelName, false);
+	if (LevelData.IsValid())
+	{
+		FScopeLock LevelLock(&LevelData->Mutex);
+
+		return LevelData->LevelActors.RenameObject(OldName, NewName);
+	}
 	return false;
 }
 

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -928,6 +928,8 @@ void USpudState::LoadFromArchive(FArchive& Ar, bool bFullyLoadAllLevelData)
 {
 	// Firstly, destroy any active game level files
 	RemoveAllActiveGameLevelFiles();
+
+	Source = Ar.GetArchiveName();
 	
 	FSpudChunkedDataArchive ChunkedAr(Ar);
 	if (bFullyLoadAllLevelData)

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -605,6 +605,17 @@ void USpudSubsystem::ForceReset()
 	CurrentState = ESpudSystemState::RunningIdle;
 }
 
+void USpudSubsystem::SetUserDataModelVersion(int32 Version)
+{
+	GCurrentUserDataModelVersion = Version;
+}
+
+
+int32 USpudSubsystem::GetUserDataModelVersion() const
+{
+	return GCurrentUserDataModelVersion;
+}
+
 void USpudSubsystem::PostUnloadStreamLevel(int32 LinkID)
 {
 	FScopeLock PendingUnloadLock(&LevelsPendingUnloadMutex);

--- a/Source/SPUD/Public/SpudData.h
+++ b/Source/SPUD/Public/SpudData.h
@@ -637,6 +637,8 @@ struct SPUD_API FSpudClassMetadata : public FSpudChunk
 	
 	bool RenameClass(const FString& OldClassName, const FString& NewClassName);
 	bool RenameProperty(const FString& ClassName, const FString& OldName, const FString& NewName, const FString& OldPrefix = "", const FString& NewPrefix = "");
+	
+	bool IsUserDataModelOutdated() const { return UserDataModelVersion.Version != GCurrentUserDataModelVersion; }
 };
 
 enum SPUD_API ELevelDataStatus
@@ -660,6 +662,8 @@ struct SPUD_API FSpudGlobalData : public FSpudChunk
 	virtual void WriteToArchive(FSpudChunkedDataArchive& Ar) override;
 	virtual void ReadFromArchive(FSpudChunkedDataArchive& Ar) override;
 	void Reset();
+	
+	bool IsUserDataModelOutdated() const { return Metadata.IsUserDataModelOutdated(); }
 };
 
 struct SPUD_API FSpudLevelData : public FSpudChunk
@@ -720,6 +724,8 @@ struct SPUD_API FSpudLevelData : public FSpudChunk
 	static bool ReadLevelInfoFromArchive(FSpudChunkedDataArchive& Ar, bool bReturnToStart, FString& OutLevelName, int64& OutDataSize);
 
 	void Reset();
+
+	bool IsUserDataModelOutdated() const { return Metadata.IsUserDataModelOutdated(); }
 };
 
 /// Description of the save game, so we can just read this chunk to get info about it

--- a/Source/SPUD/Public/SpudData.h
+++ b/Source/SPUD/Public/SpudData.h
@@ -478,12 +478,17 @@ struct FSpudArray : public FSpudChunk
 	
 };
 
-struct FSpudGlobalObjectMap : public FSpudStructMapData<FString /* FName or Guid String */, FSpudNamedObjectData>
+struct FSpudNamedObjectMap : public FSpudStructMapData<FString /* FName or Guid String */, FSpudNamedObjectData>
+{
+	virtual bool RenameObject(const FString& OldName, const FString& NewName);
+};
+
+struct FSpudGlobalObjectMap : public FSpudNamedObjectMap
 {
 	virtual const char* GetMagic() const override { return SPUDDATA_GLOBALOBJECTLIST_MAGIC; }
 	virtual const char* GetChildMagic() const override { return SPUDDATA_NAMEDOBJECT_MAGIC; }
 };
-struct FSpudLevelActorMap : public FSpudStructMapData<FString /* FName String */, FSpudNamedObjectData>
+struct FSpudLevelActorMap : public FSpudNamedObjectMap
 {
 	virtual const char* GetMagic() const override { return SPUDDATA_LEVELACTORLIST_MAGIC; }
 	virtual const char* GetChildMagic() const override { return SPUDDATA_NAMEDOBJECT_MAGIC; }

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -253,7 +253,7 @@ public:
 
 	/// Save all contents to an archive
 	/// This includes all paged out level data, which will be recombined
-	virtual void SaveToArchive(FArchive& Ar, const FText& Title);
+	virtual void SaveToArchive(FArchive& Ar);
 
 	/**
 	 * @brief 

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -60,10 +60,13 @@ class SPUD_API USpudState : public UObject
 
 	friend class USpudStateCustomData;
 
+public:
+	/// Direct access to save data - not recommended but if you really need it...
+	FSpudSaveData SaveData;
+
 protected:
 
 	FString Source;
-	FSpudSaveData SaveData;
 
 	void WriteCoreActorData(AActor* Actor, FArchive& Out) const;
 
@@ -270,13 +273,53 @@ public:
 	bool IsLevelDataLoaded(const FString& LevelName);
 
 	/// Clear the state for a given level (does not reset a loaded level, just deletes saved state)
+	UFUNCTION(BlueprintCallable)
 	void ClearLevel(const FString& LevelName);
 
 	/// Get the source of this state (e.g. save file), if any;
 	UFUNCTION(BlueprintCallable)
 	const FString& GetSource() const { return Source; }
 
-    void SetSource(const FString& NewSrc) { Source = NewSrc; }
+	/// Get the title associated with this save state 
+	UFUNCTION(BlueprintCallable)
+	const FText& GetTitle() const { return SaveData.Info.Title; }
+	/// Set the title associated with this save state 
+	UFUNCTION(BlueprintCallable)
+	void SetTitle(const FText& Title) {SaveData.Info.Title = Title; }
+
+	/// Get the timestamp for when this save state was created
+	UFUNCTION(BlueprintCallable)
+    const FDateTime& GetTimestamp() const { return SaveData.Info.Timestamp; }
+	/// Set the timestamp for when this save state was created
+	UFUNCTION(BlueprintCallable)
+    void SetTimestamp(const FDateTime& Timestamp) {SaveData.Info.Timestamp = Timestamp; }
+
+	/// Rename a class in this save data
+	/// This is for performing upgrades on save games that would otherwise be broken
+	/// Returns whether any changes were made
+	UFUNCTION(BlueprintCallable)
+	bool RenameClass(const FString& OldClassName, const FString& NewClassName);
+	
+	/// Rename a property on a class in this save data
+	/// This is for performing upgrades on save games that would otherwise be broken
+	/// OldPrefix & NewPrefix are for handling nested structs, format is "StructVarName1/StructVarName2" ofr
+	/// a property which is inside variable named StructVarName1 on the class, and then inside StructVarName2 inside that
+	/// Returns whether any changes were made
+	UFUNCTION(BlueprintCallable)
+    bool RenameProperty(const FString& ClassName, const FString& OldPropertyName, const FString& NewPropertyName, const FString& OldPrefix, const
+                        FString& NewPrefix);
+
+	/// Rename a global object so that it can be correctly found on load
+	/// This is for performing upgrades on save games that would otherwise be broken
+	/// Returns whether any changes were made
+	UFUNCTION(BlueprintCallable)
+    bool RenameGlobalObject(const FString& OldName, const FString& NewName);
+
+	/// Rename a level object so that it can be correctly found on load
+	/// This is for performing upgrades on save games that would otherwise be broken
+	/// Returns whether any changes were made
+	UFUNCTION(BlueprintCallable)
+    bool RenameLevelObject(const FString& LevelName, const FString& OldName, const FString& NewName);
 
 	/// Utility method to read *just* the information part of a save game from the start of an archive
 	/// This only reads the minimum needed to describe the save file and doesn't load any other data.

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -62,6 +62,7 @@ class SPUD_API USpudState : public UObject
 
 protected:
 
+	FString Source;
 	FSpudSaveData SaveData;
 
 	void WriteCoreActorData(AActor* Actor, FArchive& Out) const;
@@ -270,6 +271,12 @@ public:
 
 	/// Clear the state for a given level (does not reset a loaded level, just deletes saved state)
 	void ClearLevel(const FString& LevelName);
+
+	/// Get the source of this state (e.g. save file), if any;
+	UFUNCTION(BlueprintCallable)
+	const FString& GetSource() const { return Source; }
+
+    void SetSource(const FString& NewSrc) { Source = NewSrc; }
 
 	/// Utility method to read *just* the information part of a save game from the start of an archive
 	/// This only reads the minimum needed to describe the save file and doesn't load any other data.

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -27,7 +27,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSpudPreUnloadStreamingLevel, const 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSpudPostUnloadStreamingLevel, const FName&, LevelName);
 
 // Callbacks passed to functions
-DECLARE_DYNAMIC_DELEGATE_OneParam(FSpudUpgradeSaveDelegate, class USpudState*, SaveState);
+DECLARE_DYNAMIC_DELEGATE_RetVal_OneParam(bool, FSpudUpgradeSaveDelegate, class USpudState*, SaveState);
 
 UENUM(BlueprintType)
 enum class ESpudSystemState : uint8

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -331,18 +331,27 @@ public:
 	UFUNCTION(BlueprintCallable)
     int32 GetUserDataModelVersion() const;
 
-	/// Triggers the upgrade process for all save games (asynchronously)
-	/// Each save game present will be fully loaded, and for each where the user data model version of any part differs from latest,
-	/// the SaveNeedsUpgrading callback will be triggered (in a background thread). That callback should perform any
-	/// changes it needs to the USpudState. When the callback completes the save will be written back to
-	/// disk.
-	/// Note that at no point will any actors or levels be loaded. All changes made to the save are done manually so
-	/// that next time they need to be applied to real game objects, the state is as you need it to be.
-	/// If for some reason you need to have the actors loaded to perform the upgrade, then you should instead
-	/// implement ISpudObjectCallback on those objects and perform the upgrades there instead (this cannot be done in
-	/// bulk though, only on demand as each object is loaded).
+	/**
+	 * @brief Triggers the upgrade process for all save games (asynchronously)
+	 * @details Each save game present will be fully loaded, and for each where the user data model version of any part differs from latest,
+     * the SaveNeedsUpgrading callback will be triggered (in a background thread). That callback should perform any
+     * changes it needs to the USpudState. When the callback completes the save will be written back to
+     * disk if the callback returned true.
+     * Note that at no point will any actors or levels be loaded. All changes made to the save are done manually so
+     * that next time they need to be applied to real game objects, the state is as you need it to be.
+     * If for some reason you need to have the actors loaded to perform the upgrade, then you should instead
+     * implement ISpudObjectCallback on those objects and perform the upgrades there instead (this cannot be done in
+     * bulk though, only on demand as each object is loaded).
+	 * @param WorldContextObject World context object
+	 * @param bUpgradeEvenIfNoUserDataModelVersionDifferences The default behaviour is to only upgrade save games where
+	 * the UserDataModelVersion in the save differs from the current user model version. You can therefore control which
+	 * saves need manual upgrading by incrementing SetUserDataModelVersion when you have a breaking change. Set this
+	 * argument to true to process all saves instead.
+	 * @param SaveNeedsUpgradingCallback The delegate which will be called for each save which needs upgrading 
+	 * @param LatentInfo Completion callback
+	 */
 	UFUNCTION(BlueprintCallable, meta=(Latent, WorldContext="WorldContextObject", LatentInfo = "LatentInfo"), Category="SPUD")
-	static void UpgradeAllSaveGames(const UObject* WorldContextObject, FSpudUpgradeSaveDelegate SaveNeedsUpgradingCallback, FLatentActionInfo LatentInfo);
+	static void UpgradeAllSaveGames(const UObject* WorldContextObject, bool bUpgradeEvenIfNoUserDataModelVersionDifferences, FSpudUpgradeSaveDelegate SaveNeedsUpgradingCallback, FLatentActionInfo LatentInfo);
 	
 	static FString GetSaveGameDirectory();
 	static FString GetSaveGameFilePath(const FString& SlotName);

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -347,7 +347,8 @@ public:
 	 * the UserDataModelVersion in the save differs from the current user model version. You can therefore control which
 	 * saves need manual upgrading by incrementing SetUserDataModelVersion when you have a breaking change. Set this
 	 * argument to true to process all saves instead.
-	 * @param SaveNeedsUpgradingCallback The delegate which will be called for each save which needs upgrading 
+	 * @param SaveNeedsUpgradingCallback The delegate which will be called for each save which needs upgrading. Important:
+	 * the save game will only be re-written to disk if you return true from this callback. A backup will be made of the previous save.
 	 * @param LatentInfo Completion callback
 	 */
 	UFUNCTION(BlueprintCallable, meta=(Latent, WorldContext="WorldContextObject", LatentInfo = "LatentInfo"), Category="SPUD")

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -300,6 +300,34 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly)
     void ForceReset();
 
+	/// Set the version number recorded with world's data model in all save data written after this.
+	/// This is for use when you need to explicitly upgrade save games because of a change in the
+	/// classes / properties being saved, and the default property name matching rules are not enough.
+	/// Many changes to what you save are non-breaking. For example the following are not breaking:
+	/// 1. Adding new classes that are saved (they just won't be populated from old save games)
+	/// 2. Adding new SaveGame properties (they just won't be changed by loading old saves)
+	/// 3. Removing classes or properties (that data in old saves will be ignored)
+	///
+	/// Mostly it will just mean that you either lose some old data (fine if you don't care) or get the defaults
+	/// when you pull in data from old saves.
+	///
+	/// However, renaming things or making more significant changes where you need to upgrade the data through a
+	/// more explicit transformation process can be a problem.
+	/// That is what this UserDataModelVersion is for. If you never set it, it will be 0. This number will be written
+	/// into the metadata of all save data.
+	///
+	/// If you later make a change to your save data which you need to explicitly upgrade, then you should increment
+	/// this number (call this function before you need to save/load any data, as part of your game startup routine).
+	/// 
+	/// If, when loading some object data, the number in the data is different to this version, then all data for objects
+	/// described by the old version will be fed through a user-defined upgrade hook, to allow you to make manual fixes.
+	UFUNCTION(BlueprintCallable)
+    void SetUserDataModelVersion(int32 Version);
+
+	/// Gets the current version number of your game's data model (@see SetUserDataModelVersion for more details)
+	UFUNCTION(BlueprintCallable)
+    int32 GetUserDataModelVersion() const;
+	
 	static FString GetSaveGameDirectory();
 	static FString GetSaveGameFilePath(const FString& SlotName);
 	static FString GetActiveGameFolder();


### PR DESCRIPTION
Provide some ability to upgrade saves with more manual intervention than just property matching. Includes being able to rename classes & properties, move properties around in nested structs, and rename instances.