### PR TITLE
Support saving nested UObjects

### DIFF
--- a/Source/SPUD/Private/SpudData.cpp
+++ b/Source/SPUD/Private/SpudData.cpp
@@ -559,7 +559,12 @@ const FString& FSpudClassMetadata::GetClassNameFromID(uint32 ID) const
 }
 uint32 FSpudClassMetadata::FindOrAddClassIDFromName(const FString& Name)
 {
-	return ClassNameIndex.FindOrAddIndex(Name);
+	uint32 Ret = ClassNameIndex.FindOrAddIndex(Name);
+
+	if (Ret == SPUDDATA_CLASSID_NONE)
+		UE_LOG(LogSpudData, Fatal, TEXT("Too many classes (seriously, how did you manage this? 4M classes? Woah)"))
+	
+	return Ret;
 }
 uint32 FSpudClassMetadata::GetClassIDFromName(const FString& Name) const
 {

--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -396,7 +396,7 @@ FString SpudPropertyUtil::WriteActorRefPropertyData(FObjectProperty* OProp, AAct
 	return RefString;
 }
 
-uint32 SpudPropertyUtil::WriteNestedUObjectPropertyData(FObjectProperty* OProp, UObject* UObj, uint32 PrefixID, const void* Data,
+FString SpudPropertyUtil::WriteNestedUObjectPropertyData(FObjectProperty* OProp, UObject* UObj, uint32 PrefixID, const void* Data,
 	bool bIsArrayElement, FSpudClassDef& ClassDef, TArray<uint32>& PropertyOffsets, FSpudClassMetadata& Meta,
 	FArchive& Out)
 {
@@ -404,11 +404,13 @@ uint32 SpudPropertyUtil::WriteNestedUObjectPropertyData(FObjectProperty* OProp, 
 		RegisterProperty(OProp, PrefixID, ClassDef, PropertyOffsets, Meta, Out);
 
 	uint32 ClassID;
+	FString Ret = "NULL";
 	// We already have the Actor so no need to get property value
 	if (UObj)
 	{		
 		// UObjects (not actor refs) are just stored as the class (as an ID)
-		ClassID = Meta.FindOrAddClassIDFromName(GetClassName(UObj));
+		Ret = GetClassName(UObj);
+		ClassID = Meta.FindOrAddClassIDFromName(Ret);
 		// Nested properties are stored like UStructs, as value types, except that we may need to re-construct them
 		// Note that we use the full name not the ClassID 
 	}
@@ -416,7 +418,7 @@ uint32 SpudPropertyUtil::WriteNestedUObjectPropertyData(FObjectProperty* OProp, 
 		ClassID = SPUDDATA_CLASSID_NONE;
 	
 	Out << ClassID;
-	return ClassID;
+	return Ret;
 }
 
 bool SpudPropertyUtil::TryWriteUObjectPropertyData(FProperty* Property, uint32 PrefixID, const void* Data,
@@ -440,9 +442,9 @@ bool SpudPropertyUtil::TryWriteUObjectPropertyData(FProperty* Property, uint32 P
 		{
 			// non-actor UObject
 			// We store non-Actor UObjects as just the class name, so they can be instantiated if need be
-			const uint32 Val = WriteNestedUObjectPropertyData(OProp, Obj, PrefixID, Data, bIsArrayElement, ClassDef,
+			const FString Val = WriteNestedUObjectPropertyData(OProp, Obj, PrefixID, Data, bIsArrayElement, ClassDef,
 														PropertyOffsets, Meta, Out);
-			UE_LOG(LogSpudProps, Verbose, TEXT("|%s %s = %s"), *Prefix, *OProp->GetNameCPP(), *ToString(Val));
+			UE_LOG(LogSpudProps, Verbose, TEXT("|%s %s = %s"), *Prefix, *OProp->GetNameCPP(), *Val);
 		}
 		return true;
 	}

--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -232,25 +232,27 @@ bool SpudPropertyUtil::VisitPersistentProperties(UObject* RootObject, const UStr
 					return false;				
 			}
 		}
-		// Nested non-Actor UObjects not really working, needs more work
-		// else if (const auto OProp = CastField<FObjectProperty>(Property))
-		// {
-		// 	if (IsNonActorObjectProperty(Property))
-		// 	{
-		// 		const auto Obj = ContainerPtr ? OProp->GetObjectPropertyValue(ContainerPtr) : nullptr;
-		// 		const auto ObjDataPtr = ContainerPtr ? OProp->ContainerPtrToValuePtr<void>(ContainerPtr) : nullptr;
-		// 		// Non-actor UObjects are treated as nested values like structs
-		// 		const uint32 NewPrefixID = Visitor.GetNestedPrefix(OProp, PrefixID);
-		// 		// Should never have no prefix, if none abort
-		// 		if (NewPrefixID == SPUDDATA_PREFIXID_NONE)
-		// 			continue;
-		//
-		// 		const int NewDepth = Depth + 1;
-		// 		if (!VisitPersistentProperties(Obj, OProp->PropertyClass, NewPrefixID, ObjDataPtr, true, NewDepth, Visitor))
-		// 			return false;				
-		// 		
-		// 	}
-		// }
+		else if (const auto OProp = CastField<FObjectProperty>(Property))
+		{
+			if (IsNonActorObjectProperty(Property))
+			{
+				const void* DataPtr = ContainerPtr ? Property->ContainerPtrToValuePtr<void>(ContainerPtr) : nullptr;
+				const auto Obj = DataPtr ? OProp->GetObjectPropertyValue(DataPtr) : nullptr;
+
+				if (IsValid(Obj))
+				{
+					// Non-actor UObjects are treated as nested values like structs
+					const uint32 NewPrefixID = Visitor.GetNestedPrefix(OProp, PrefixID);
+					// Should never have no prefix, if none abort
+					if (NewPrefixID == SPUDDATA_PREFIXID_NONE)
+						continue;
+			
+					const int NewDepth = Depth + 1;
+					if (!VisitPersistentProperties(RootObject, Obj->GetClass(), NewPrefixID, Obj, true, NewDepth, Visitor))
+						return false;
+				}				
+			}
+		}
 	}
 
 	return true;
@@ -546,16 +548,15 @@ void SpudPropertyUtil::StoreContainerProperty(FProperty* Property, const UObject
 			bUpdateOK = true;
 		}
 	}
-	// Nested non-Actor UObjects not really working, needs more work
-	// else if (IsNonActorObjectProperty(Property))
-	// {
-	// 	// Nested non-actor objects are ok, recursed like structs
-	// 	// Visitor will cascade
-	// 	const FString Prefix = FString::ChrN(Depth, '-');
-	// 	UE_LOG(LogSpudProps, Verbose, TEXT("|%s %s:"), *Prefix, *Property->GetNameCPP());
-	// 	bUpdateOK = true;
-	// 	
-	// }
+	else if (IsNonActorObjectProperty(Property))
+	{
+		// Nested non-actor objects are recursed like custom structs
+		// Visitor will cascade
+		const FString Prefix = FString::ChrN(Depth, '-');
+		UE_LOG(LogSpudProps, Verbose, TEXT("|%s %s:"), *Prefix, *Property->GetNameCPP());
+		bUpdateOK = true;
+		
+	}
 	else 
 	{
 		bUpdateOK =
@@ -649,13 +650,12 @@ void SpudPropertyUtil::RestoreContainerProperty(UObject* RootObject, FProperty* 
 			bUpdateOK = true;
 		}
 	}
-	// Nested non-Actor UObjects not really working, needs more work
-	// else if (IsNonActorObjectProperty(Property))
-	// {
-	// 	// Nested non-actor objects are ok, recursed like structs
-	// 	// Visitor will cascade
-	// 	bUpdateOK = true;		
-	// }
+	else if (IsNonActorObjectProperty(Property))
+	{
+		// Nested non-actor objects are ok, recursed like structs
+		// Visitor will cascade
+		bUpdateOK = true;		
+	}
 	else 
 	{
 		bUpdateOK =

--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -36,6 +36,11 @@ bool SpudPropertyUtil::IsValidArrayType(FArrayProperty* AProp)
 		if (!IsBuiltInStructProperty(SProp))
 			return false;
 	}
+	else if (IsNonActorObjectProperty(AProp->Inner))
+	{
+		// Same problem with nested UObjects
+		return false;
+	}
 	return true;
 
 }

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -83,7 +83,7 @@ bool USpudState::StorePropertyVisitor::VisitProperty(UObject* RootObject, FPrope
 void USpudState::StorePropertyVisitor::UnsupportedProperty(UObject* RootObject,
     FProperty* Property, uint32 CurrentPrefixID, int Depth)
 {
-	UE_LOG(LogSpudState, Error, TEXT("Property %s/%s is marked for save but is an unsupported type, ignoring. E.g. Arrays of custom structs are not supported."),
+	UE_LOG(LogSpudState, Error, TEXT("Property %s/%s is marked for save but is an unsupported type, ignoring. E.g. Arrays of custom structs or nested UObjects (other than actor refs) are not supported."),
         *RootObject->GetName(), *Property->GetName());
 	
 }

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -726,9 +726,9 @@ bool USpudState::RestoreFastPropertyVisitor::VisitProperty(UObject* RootObject, 
 		auto& StoredProperty = *StoredPropertyIterator;
 		SpudPropertyUtil::RestoreProperty(RootObject, Property, ContainerPtr, StoredProperty, RuntimeObjects, DataIn);
 
-		// We DON'T increment the property iterator for custom structs, since they don't have any values of their own
+		// We DON'T increment the property iterator for custom structs and nested UObjects, since they don't have any values of their own
 		// It's their nested properties that have the values, they're only context
-		if (!SpudPropertyUtil::IsCustomStructProperty(Property))
+		if (!SpudPropertyUtil::IsCustomStructProperty(Property) && !SpudPropertyUtil::IsNonActorObjectProperty(Property))
 			++StoredPropertyIterator;
 
 		return true;

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -719,9 +719,9 @@ bool USpudState::RestoreFastPropertyVisitor::VisitProperty(UObject* RootObject, 
 		auto& StoredProperty = *StoredPropertyIterator;
 		SpudPropertyUtil::RestoreProperty(RootObject, Property, ContainerPtr, StoredProperty, RuntimeObjects, Meta, DataIn);
 
-		// We DON'T increment the property iterator for custom structs and nested UObjects, since they don't have any values of their own
+		// We DON'T increment the property iterator for custom structs, since they don't have any values of their own
 		// It's their nested properties that have the values, they're only context
-		if (!SpudPropertyUtil::IsCustomStructProperty(Property) && !SpudPropertyUtil::IsNonActorObjectProperty(Property))
+		if (!SpudPropertyUtil::IsCustomStructProperty(Property))
 			++StoredPropertyIterator;
 
 		return true;

--- a/Source/SPUD/Public/ISpudObject.h
+++ b/Source/SPUD/Public/ISpudObject.h
@@ -61,18 +61,21 @@ public:
 	// I fixed this mainly by making USpudState not a USaveGame and doing everything manually instead, no
 	// Serialize() methods.
 	
-	/// Called just before this object and its SaveGame properties are persisted into a game state
+	/// Called just before this object and its SaveGame properties are persisted into a game state.
+	/// This is called for root saved objects and nested UObjects
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudPreStore(const USpudState* State);
 	
 	/// Called just after all the automatic property data has been written to the state for this object, but before the
 	/// record is sealed. This is the place you can write any custom data you need that you can't expose in a UPROPERTY
 	/// for some reason. Use methods on USpudStateCustomData to write custom data.
-	/// You are in charge of making sure you write/read the same data in the finalise methods
+	/// You are in charge of making sure you write/read the same data in the finalise methods.
+	/// This is only called for root objects (Actors and global objects), not nested UObjects, which cannot store custom data
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudStoreCustomData(const USpudState* State, USpudStateCustomData* CustomData);
 
 	/// Called just after this object and its SaveGame properties have been persisted (no further state can be written for this object)
+	/// This is called for root objects and nested UObjects
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudPostStore(const USpudState* State);
 
@@ -81,10 +84,12 @@ public:
 	/// benefit of having the actual object available. At this point you should probably only be modifying USpudState,
 	/// to make it compatible, because the normal restore will still happen after this. See SpudPostRestoreDataModelUpgrade
 	/// if you want to alter things afterwards.
+	/// This is only called for root objects (actors and global objects), not nested UObjects
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudPreRestoreDataModelUpgrade(USpudState* State, int32 StoredVersion, int32 CurrentVersion);
 	
 	/// Called just before this object's state is populated from a persistent state
+	/// This is called for root objects and nested UObjects
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudPreRestore(const USpudState* State);
 	
@@ -92,6 +97,7 @@ public:
 	/// record is finished. This is the place you can read any custom data you wrote during
 	/// for some reason. Use methods on USpudStateCustomData to write custom data.
 	/// You are in charge of making sure you write/read the same data in the finalise methods
+	/// This is only called for root objects (actors and global objects), not nested UObjects
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudRestoreCustomData(USpudState* State, USpudStateCustomData* CustomData);
 
@@ -99,10 +105,12 @@ public:
 	/// This is an alternative to calling UpgradeAllSaveGames on USpudSubsystem, you can upgrade on demand with the
 	/// benefit of having the actual object available. At this point the normal restore process has occurred but you
 	/// can do some post-restore things specific to the data model being changed.
+	/// This is only called for root objects (actors and global objects), not nested UObjects
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudPostRestoreDataModelUpgrade(const USpudState* State, int32 StoredVersion, int32 CurrentVersion);
 
 	/// Called just after the state for this object has been fully restored.
+	/// This is called for root objects and nested UObjects
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD")
     void SpudPostRestore(const USpudState* State);
 

--- a/Source/SPUD/Public/SpudData.h
+++ b/Source/SPUD/Public/SpudData.h
@@ -65,7 +65,7 @@ extern int32 GCurrentUserDataModelVersion;
 
 enum SPUD_API ESpudStorageType // (stored as uint16 but not using enum class to make bitwise ops easier)
 {
-	// All of these are serilized as per their underlying types
+	// All of these are serialised as per their underlying types
 	ESST_UInt8 = 0,
     ESST_UInt16 = 1,
     ESST_UInt32 = 2,

--- a/Source/SPUD/Public/SpudData.h
+++ b/Source/SPUD/Public/SpudData.h
@@ -37,6 +37,7 @@ extern int32 GCurrentUserDataModelVersion;
 #define SPUDDATA_INDEX_NONE 0xFFFFFFFF
 #define SPUDDATA_PROPERTYID_NONE 0xFFFFFFFF
 #define SPUDDATA_PREFIXID_NONE 0xFFFFFFFF
+#define SPUDDATA_CLASSID_NONE 0xFFFFFFFF
 
 // None of the structs in this file are exposed to Blueprints. They are theoretically available to external code
 // via C++ but honestly external code should just use the API on USpudSubsystem, or USpudState at a push (save upgrading)

--- a/Source/SPUD/Public/SpudPropertyUtil.h
+++ b/Source/SPUD/Public/SpudPropertyUtil.h
@@ -102,6 +102,41 @@ public:
 		* nested properties will be skipped.
 		 */
 		virtual uint32 GetNestedPrefix(FProperty* Prop, uint32 CurrentPrefixID) = 0;
+
+		/**
+		 * Called just before descending into a struct 
+		 * @param RootObject The root object being traversed
+		 * @param SProp The property of the struct
+		 * @param PrefixID The prefix ID for members of the struct
+		 * @param Depth The depth for members of the struct
+		 */
+		virtual void StartNestedStruct(UObject* RootObject, FStructProperty* SProp, uint32 PrefixID, int Depth) {}
+		/**
+		 * Called just after all the members of a struct have been visited 
+		 * @param RootObject The root object being traversed
+		 * @param SProp The property of the struct
+		 * @param PrefixID The prefix ID for members of the struct
+		 * @param Depth The depth for members of the struct
+		 */
+		virtual void EndNestedStruct(UObject* RootObject, FStructProperty* SProp, uint32 PrefixID, int Depth) {}
+		/**
+		* Called just before descending into a UObject 
+		* @param RootObject The root object being traversed
+		* @param OProp The property of the object
+		* @param PrefixID The prefix ID for members of the object
+		* @param Depth The depth for members of the object
+		* @param NestedObject Pointer to the nested object, may be null
+		*/
+		virtual void StartNestedUObject(UObject* RootObject, FObjectProperty* OProp, uint32 PrefixID, int Depth, UObject* NestedObject) {}
+		/**
+		* Called just after all members of a nested UObject have been visited 
+		* @param RootObject The root object being traversed
+		* @param OProp The property of the object
+		* @param PrefixID The prefix ID for members of the object
+		* @param Depth The depth for members of the object
+		* @param NestedObject Pointer to the nested object, may be null
+		*/
+		virtual void EndNestedUObject(UObject* RootObject, FObjectProperty* OProp, uint32 PrefixID, int Depth, UObject* NestedObject) {}
 	};
 
 	/**

--- a/Source/SPUD/Public/SpudPropertyUtil.h
+++ b/Source/SPUD/Public/SpudPropertyUtil.h
@@ -295,7 +295,7 @@ protected:
 	static FString WriteActorRefPropertyData(FObjectProperty* OProp, AActor* Actor, FPlatformTypes::uint32 PrefixID, const void* Data,
 	                                         bool bIsArrayElement, FSpudClassDef& ClassDef,
 	                                         TArray<uint32>& PropertyOffsets, FSpudClassMetadata& Meta, FArchive& Out);
-	static uint32 WriteNestedUObjectPropertyData(FObjectProperty* OProp, UObject* UObj, FPlatformTypes::uint32 PrefixID, const void* Data,
+	static FString WriteNestedUObjectPropertyData(FObjectProperty* OProp, UObject* UObj, FPlatformTypes::uint32 PrefixID, const void* Data,
 											bool bIsArrayElement, FSpudClassDef& ClassDef,
 											TArray<uint32>& PropertyOffsets, FSpudClassMetadata& Meta, FArchive& Out);
 	static bool TryWriteUObjectPropertyData(FProperty* Property, uint32 PrefixID, const void* Data, bool bIsArrayElement,

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -98,7 +98,6 @@ protected:
 
 	FSpudSaveData::TLevelDataPtr GetLevelData(const FString& LevelName, bool AutoCreate);
 	FSpudNamedObjectData* GetLevelActorData(const AActor* Actor, FSpudSaveData::TLevelDataPtr LevelData, bool AutoCreate);
-	static FString GetClassName(const UObject* Obj);
 	FSpudSpawnedActorData* GetSpawnedActorData(AActor* Actor, FSpudSaveData::TLevelDataPtr LevelData, bool AutoCreate);
 	FSpudNamedObjectData* GetGlobalObjectData(const UObject* Obj, bool AutoCreate);
 	FSpudNamedObjectData* GetGlobalObjectData(const FString& ID, bool AutoCreate);

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -81,19 +81,23 @@ protected:
 	class StorePropertyVisitor : public SpudPropertyUtil::PropertyVisitor
 	{
 	protected:
-		// Bare UObject but safe because we only call it inside GameState itself
+		USpudState* ParentState; // weak, but safe to use in scope
 		FSpudClassDef& ClassDef;
 		TArray<uint32>& PropertyOffsets;
 		FSpudClassMetadata& Meta;
 		FMemoryWriter& Out;
 	public:
-		StorePropertyVisitor(FSpudClassDef& InClassDef, TArray<uint32>& InPropertyOffsets, FSpudClassMetadata& InMeta, FMemoryWriter& InOut);
+		StorePropertyVisitor(USpudState* ParentState, FSpudClassDef& InClassDef, TArray<uint32>& InPropertyOffsets, FSpudClassMetadata& InMeta, FMemoryWriter& InOut);
 		virtual bool VisitProperty(UObject* RootObject, FProperty* Property, uint32 CurrentPrefixID,
 		                           void* ContainerPtr, int Depth) override;
 
 		virtual void UnsupportedProperty(UObject* RootObject, FProperty* Property, uint32 CurrentPrefixID,
 			int Depth) override;
 		virtual uint32 GetNestedPrefix(FProperty* Prop, uint32 CurrentPrefixID) override;
+		virtual void StartNestedUObject(UObject* RootObject, FObjectProperty* OProp, uint32 PrefixID, int Depth,
+			UObject* NestedObject) override;
+		virtual void EndNestedUObject(UObject* RootObject, FObjectProperty* OProp, uint32 PrefixID, int Depth,
+			UObject* NestedObject) override;
 	};
 
 	FSpudSaveData::TLevelDataPtr GetLevelData(const FString& LevelName, bool AutoCreate);
@@ -131,15 +135,20 @@ protected:
 	class RestorePropertyVisitor : public SpudPropertyUtil::PropertyVisitor
 	{
 	protected:
+		USpudState* ParentState; // weak but ok since used in scope
 		const FSpudClassDef& ClassDef;
 		const FSpudClassMetadata& Meta;
 		const TMap<FGuid, UObject*>* RuntimeObjects;
 		FMemoryReader& DataIn;
 	public:
-		RestorePropertyVisitor(FMemoryReader& InDataIn, const FSpudClassDef& InClassDef, const FSpudClassMetadata& InMeta, const TMap<FGuid, UObject*>* InRuntimeObjects):
-			ClassDef(InClassDef), Meta(InMeta), RuntimeObjects(InRuntimeObjects), DataIn(InDataIn) {}
+		RestorePropertyVisitor(USpudState* Parent, FMemoryReader& InDataIn, const FSpudClassDef& InClassDef, const FSpudClassMetadata& InMeta, const TMap<FGuid, UObject*>* InRuntimeObjects):
+			ParentState(Parent), ClassDef(InClassDef), Meta(InMeta), RuntimeObjects(InRuntimeObjects), DataIn(InDataIn) {}
 
-		virtual uint32 GetNestedPrefix(FProperty* Prop, uint32 CurrentPrefixID) override;		
+		virtual uint32 GetNestedPrefix(FProperty* Prop, uint32 CurrentPrefixID) override;
+		virtual void StartNestedUObject(UObject* RootObject, FObjectProperty* OProp, uint32 PrefixID, int Depth,
+			UObject* NestedObject) override;
+		virtual void EndNestedUObject(UObject* RootObject, FObjectProperty* OProp, uint32 PrefixID, int Depth,
+			UObject* NestedObject) override;
 	};
 
 
@@ -149,10 +158,10 @@ protected:
 	protected:
 		TArray<FSpudPropertyDef>::TConstIterator StoredPropertyIterator;
 	public:
-		RestoreFastPropertyVisitor(const TArray<FSpudPropertyDef>::TConstIterator& InStoredPropertyIterator,
+		RestoreFastPropertyVisitor(USpudState* Parent, const TArray<FSpudPropertyDef>::TConstIterator& InStoredPropertyIterator,
 		                           FMemoryReader& InDataIn, const FSpudClassDef& InClassDef,
 		                           const FSpudClassMetadata& InMeta, const TMap<FGuid, UObject*>* InRuntimeObjects)
-			: RestorePropertyVisitor(InDataIn, InClassDef, InMeta, InRuntimeObjects),
+			: RestorePropertyVisitor(Parent, InDataIn, InClassDef, InMeta, InRuntimeObjects),
 			  StoredPropertyIterator(InStoredPropertyIterator)
 		{
 		}
@@ -165,8 +174,8 @@ protected:
 	class RestoreSlowPropertyVisitor : public RestorePropertyVisitor
 	{
 	public:
-		RestoreSlowPropertyVisitor(FMemoryReader& InDataIn, const FSpudClassDef& InClassDef, const FSpudClassMetadata& InMeta, const TMap<FGuid, UObject*>* InRuntimeObjects)
-			: RestorePropertyVisitor(InDataIn, InClassDef, InMeta, InRuntimeObjects) {}
+		RestoreSlowPropertyVisitor(USpudState* Parent, FMemoryReader& InDataIn, const FSpudClassDef& InClassDef, const FSpudClassMetadata& InMeta, const TMap<FGuid, UObject*>* InRuntimeObjects)
+			: RestorePropertyVisitor(Parent, InDataIn, InClassDef, InMeta, InRuntimeObjects) {}
 
 		virtual bool VisitProperty(UObject* RootObject, FProperty* Property, uint32 CurrentPrefixID,
 		                           void* ContainerPtr, int Depth) override;

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -132,8 +132,8 @@ a large or even infinite drop, then you might need to tweak this a bit.
 ## Cross-references across streaming level boundaries
 
 Persistent object cross-references are supported as saved state. However, 
-they can only reference objects in the same level, because you cannot guarantee
-that both levels are loaded at once.
+they can only reference objects in the same level, or in the Persistent level, 
+because you cannot guarantee which levels are loaded at once.
 
 If objects needs to cross streaming level boundaries then you might consider
 putting them in the Persistent Level instead of the streamed level. However, 

--- a/doc/props.md
+++ b/doc/props.md
@@ -29,12 +29,15 @@ The following property types are supported, either as single entries, or
 * Rotator (FRotator)
 * Transform (FTransform)
 * Guid (FGuid)
-* Object Reference (Any type of object)
+* Actor references
+
+The following property types are supported, but **not as arrays**:
+
+* Custom UStructs
+* Nested UObject instances (null preserving, will re-instantiate based on property type)
 
 Maps and sets are not supported. 
 
-In addition, any other struct is supported, including custom structs - but 
-**not as arrays**. 
 
 ## Upgrading Properties
 


### PR DESCRIPTION
This feature supports saving/loading plain UObject properties, not just Actor references. Arrays of them aren't supported for the same reason as custom struct arrays - providing backwards compatibility when arrays of nested structures change is too awkward right now (knowing the length in the data buffer is tricky).

UObjects are re-instantiated based on the property type when restoring if the property is currently null, otherwise the existing instance is re-populated. If you need to initialise the UObject with a subclass before loading, use the `ISpudObjectCallback` PreRestore hook on the parent object.

Nested UObjects get pre/post calls if they implement `ISpudObjectCallback` as well, but not the custom data or migration hooks.