### PR TITLE
Support using built-in UE streaming volumes

### DIFF
--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -116,6 +116,16 @@ bool USpudSubsystem::IsAutoSave(const FString& SlotName)
 	return SlotName == SPUD_AUTOSAVE_SLOTNAME;
 }
 
+void USpudSubsystem::NotifyLevelLoadedExternally(FName LevelName)
+{
+	HandleLevelLoaded(LevelName);
+}
+
+void USpudSubsystem::NotifyLevelUnloadedExternally(ULevel* Level)
+{
+	HandleLevelUnloaded(Level);
+}
+
 void USpudSubsystem::LoadLatestSaveGame()
 {
 	auto Latest = GetLatestSaveGame();
@@ -355,6 +365,37 @@ void USpudSubsystem::SaveComplete(const FString& SlotName, bool bSuccess)
 	ExtraInfoInProgress = nullptr;
 	CurrentState = ESpudSystemState::RunningIdle;
 	PostSaveGame.Broadcast(SlotName, bSuccess);
+}
+
+void USpudSubsystem::HandleLevelLoaded(FName LevelName)
+{
+	// Defer the restore to the game thread, streaming calls happen in loading thread?
+	// However, quickly ping the state to force it to pre-load the leveldata
+	// that way the loading occurs in this thread, less latency
+	GetActiveState()->PreLoadLevelData(LevelName.ToString());
+
+	AsyncTask(ENamedThreads::GameThread, [this, LevelName]()
+		{
+			// But also add a slight delay so we get a tick in between so physics works
+			FTimerHandle H;
+			GetWorld()->GetTimerManager().SetTimer(H, [this, LevelName]()
+				{
+					PostLoadStreamLevelGameThread(LevelName);
+				}, 0.01, false);
+		});
+}
+
+void USpudSubsystem::HandleLevelUnloaded(ULevel* Level)
+{
+	UnsubscribeLevelObjectEvents(Level);
+
+	if (CurrentState != ESpudSystemState::LoadingGame)
+	{
+		// save the state, if not loading game
+		// when loading game we will unload the current level and streaming and don't want to restore the active state from that
+		// After storing, the level data is released so doesn't take up memory any more
+		StoreLevel(Level, true, false);
+	}
 }
 
 
@@ -920,37 +961,6 @@ FString USpudSubsystem::GetActiveGameFolder()
 FString USpudSubsystem::GetActiveGameFilePath(const FString& Name)
 {
 	return FString::Printf(TEXT("%sSaveGames/%s.sav"), *GetActiveGameFolder(), *Name);
-}
-
-void USpudSubsystem::HandleLevelUnloaded(ULevel* Level)
-{
-	UnsubscribeLevelObjectEvents(Level);
-
-	if (CurrentState != ESpudSystemState::LoadingGame)
-	{
-		// save the state, if not loading game
-		// when loading game we will unload the current level and streaming and don't want to restore the active state from that
-		// After storing, the level data is released so doesn't take up memory any more
-		StoreLevel(Level, true, false);
-	}
-}
-
-void USpudSubsystem::HandleLevelLoaded(FName LevelName)
-{
-	// Defer the restore to the game thread, streaming calls happen in loading thread?
-	// However, quickly ping the state to force it to pre-load the leveldata
-	// that way the loading occurs in this thread, less latency
-	GetActiveState()->PreLoadLevelData(LevelName.ToString());			
-
-	AsyncTask(ENamedThreads::GameThread, [this, LevelName]()
-    {
-		// But also add a slight delay so we get a tick in between so physics works
-		FTimerHandle H;
-		GetWorld()->GetTimerManager().SetTimer(H, [this, LevelName]()
-		{
-			PostLoadStreamLevelGameThread(LevelName);				
-		}, 0.01, false);
-    });		
 }
 
 

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -211,6 +211,9 @@ protected:
 	void LoadComplete(const FString& SlotName, bool bSuccess);
 	void SaveComplete(const FString& SlotName, bool bSuccess);
 
+	void HandleLevelLoaded(FName LevelName);
+	void HandleLevelUnloaded(ULevel* Level);
+
 	void LoadStreamLevel(FName LevelName, bool Blocking);
 	void StartUnloadTimer();
 	void StopUnloadTimer();
@@ -222,9 +225,6 @@ public:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
 
-	void HandleLevelUnloaded(ULevel* Level);
-	void HandleLevelLoaded(FName LevelName);
-		
 	UFUNCTION(BlueprintPure)
 	bool IsLoadingGame() const { return CurrentState == ESpudSystemState::LoadingGame; }
 
@@ -435,6 +435,24 @@ public:
 	/// Useful for when parsing through saves to check if something is a manual save or not
 	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly)
     bool IsAutoSave(const FString& SlotName);
+
+	/**
+	 * Notify @see USpudSubsystem that a level was loaded externally. By default, SPUD uses its custom
+	 * @see ASpudStreamingVolume instances for notification of level streaming events. This method provides
+	 * an interface to use other methods of loading streaming levels.
+	 * @param Level The level that was loaded.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly)
+	void NotifyLevelLoadedExternally(FName LevelName);
+
+	/**
+	 * Notify @see USpudSubsystem that a level was unloaded externally. By default, SPUD uses its custom
+	 * @see ASpudStreamingVolume instances for notification of level streaming events. This method provides
+	 * an interface to use other methods of unloading streaming levels.
+	 * @param Level The level that was unloaded.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly)
+	void NotifyLevelUnloadedExternally(ULevel* Level);
 
 	static FString GetSaveGameDirectory();
 	static FString GetSaveGameFilePath(const FString& SlotName);

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -222,6 +222,9 @@ public:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
 
+	void HandleLevelUnloaded(ULevel* Level);
+	void HandleLevelLoaded(FName LevelName);
+		
 	UFUNCTION(BlueprintPure)
 	bool IsLoadingGame() const { return CurrentState == ESpudSystemState::LoadingGame; }
 


### PR DESCRIPTION
Move critical pieces of code into public functions so that SPUD can be used with other level streaming mechanisms (including the built-in one in UE4). Also, fix ordering issue with event broadcast.