### PR TITLE
Resolved Clang compilation issues.

### DIFF
--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -1032,25 +1032,25 @@ void USpudState::StoreLevelActorDestroyed(AActor* Actor, FSpudSaveData::TLevelDa
 	LevelData->DestroyedActors.Add(SpudPropertyUtil::GetLevelActorName(Actor));
 }
 
-void USpudState::SaveToArchive(FArchive& Ar)
+void USpudState::SaveToArchive(FArchive& SPUDAr)
 {
 	// We use separate read / write in order to more clearly support chunked file format
 	// with the backwards compatibility that comes with 
-	FSpudChunkedDataArchive ChunkedAr(Ar);
+	FSpudChunkedDataArchive ChunkedAr(SPUDAr);
 	SaveData.PrepareForWrite();
 	// Use WritePaged in all cases; if all data is loaded it amounts to the same thing
 	SaveData.WriteToArchive(ChunkedAr, GetActiveGameLevelFolder());
 
 }
 
-void USpudState::LoadFromArchive(FArchive& Ar, bool bFullyLoadAllLevelData)
+void USpudState::LoadFromArchive(FArchive& SPUDAr, bool bFullyLoadAllLevelData)
 {
 	// Firstly, destroy any active game level files
 	RemoveAllActiveGameLevelFiles();
 
-	Source = Ar.GetArchiveName();
+	Source = SPUDAr.GetArchiveName();
 	
-	FSpudChunkedDataArchive ChunkedAr(Ar);
+	FSpudChunkedDataArchive ChunkedAr(SPUDAr);
 	SaveData.ReadFromArchive(ChunkedAr, bFullyLoadAllLevelData, GetActiveGameLevelFolder());
 }
 
@@ -1069,9 +1069,9 @@ void USpudState::ClearLevel(const FString& LevelName)
 	SaveData.DeleteLevelData(LevelName, GetActiveGameLevelFolder());
 }
 
-bool USpudState::LoadSaveInfoFromArchive(FArchive& Ar, USpudSaveGameInfo& OutInfo)
+bool USpudState::LoadSaveInfoFromArchive(FArchive& SPUDAr, USpudSaveGameInfo& OutInfo)
 {
-	FSpudChunkedDataArchive ChunkedAr(Ar);
+	FSpudChunkedDataArchive ChunkedAr(SPUDAr);
 	FSpudSaveInfo StorageInfo;
 	const bool Ok = FSpudSaveData::ReadSaveInfoFromArchive(ChunkedAr, StorageInfo);
 	if (Ok)

--- a/Source/SPUD/Public/SpudPropertyUtil.h
+++ b/Source/SPUD/Public/SpudPropertyUtil.h
@@ -6,7 +6,7 @@
 #include "Serialization/MemoryWriter.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpudProps, Verbose, Verbose);
-
+namespace{
 /// Type info for persistence
 /// Maps a given type to:
 /// 1. An enum value, for describing how the data is stored
@@ -66,7 +66,7 @@ template <> const ESpudStorageType SpudTypeInfo<FTransform>::EnumType = ESST_Tra
 template <> const ESpudStorageType SpudTypeInfo<FGuid>::EnumType = ESST_Guid;
 template <> const ESpudStorageType SpudTypeInfo<FString>::EnumType = ESST_String;
 template <> const ESpudStorageType SpudTypeInfo<FName>::EnumType = ESST_Name;
-
+}
 /// Utility class which does all the nuts & bolts related to property persistence without actually being stateful
 /// Also none of this is exposed to Blueprints, is completely internal to C++ persistence
 class SPUD_API SpudPropertyUtil

--- a/Source/SPUD/Public/SpudState.h
+++ b/Source/SPUD/Public/SpudState.h
@@ -272,15 +272,15 @@ public:
 
 	/// Save all contents to an archive
 	/// This includes all paged out level data, which will be recombined
-	virtual void SaveToArchive(FArchive& Ar);
+	virtual void SaveToArchive(FArchive& SPUDAr);
 
 	/**
 	 * @brief 
-	 * @param Ar The save file archive
+	 * @param SPUDAr The save file archive
 	 * @param bFullyLoadAllLevelData If true, load all data into memory including all data for all levels. If false,
 	 * only load global data and enumerate levels, piping level data to separate disk files instead for loading individually later
 	 */
-	virtual void LoadFromArchive(FArchive& Ar, bool bFullyLoadAllLevelData);
+	virtual void LoadFromArchive(FArchive& SPUDAr, bool bFullyLoadAllLevelData);
 
 	/// Get the name of the persistent level which the player is on in this state
 	FString GetPersistentLevel() const { return SaveData.GlobalData.CurrentLevel; }
@@ -351,7 +351,7 @@ public:
 
 	/// Utility method to read *just* the information part of a save game from the start of an archive
 	/// This only reads the minimum needed to describe the save file and doesn't load any other data.
-	static bool LoadSaveInfoFromArchive(FArchive& Ar, USpudSaveGameInfo& OutInfo);
+	static bool LoadSaveInfoFromArchive(FArchive& SPUDAr, USpudSaveGameInfo& OutInfo);
 
 	bool bTestRequireSlowPath = false;
 	bool bTestRequireFastPath = false;
@@ -370,19 +370,19 @@ class SPUD_API USpudStateCustomData : public UObject
 {
 	GENERATED_BODY()
 protected:
-	FArchive *Ar;
+	FArchive *SPUDAr;
 
 public:
-	USpudStateCustomData() : Ar(nullptr) {}
+	USpudStateCustomData() : SPUDAr(nullptr) {}
 
 	void Init(FArchive* InOut)
 	{
-		Ar = InOut;
+		SPUDAr = InOut;
 	}
 
-	bool CanRead() const { return Ar && Ar->IsLoading(); }
-	bool CanWrite() const { return Ar && Ar->IsSaving(); }
-	bool AtEnd() const { return Ar && Ar->AtEnd(); }
+	bool CanRead() const { return SPUDAr && SPUDAr->IsLoading(); }
+	bool CanWrite() const { return SPUDAr && SPUDAr->IsSaving(); }
+	bool AtEnd() const { return SPUDAr && SPUDAr->AtEnd(); }
 
 	/// Write a value to the custom data
 	/// NOTE: May reformat some data types for efficiency, e.g. bool becomes uint8
@@ -395,7 +395,7 @@ public:
 			return;
 		}
 		
-		SpudPropertyUtil::WriteRaw(Value, *Ar);
+		SpudPropertyUtil::WriteRaw(Value, *SPUDAr);
 	}
 
 	/// Try to read a value from the custom data
@@ -413,7 +413,7 @@ public:
 			return false;
 		}
 		
-		SpudPropertyUtil::ReadRaw(OutValue, *Ar);
+		SpudPropertyUtil::ReadRaw(OutValue, *SPUDAr);
 		return true;
 	}
 
@@ -530,7 +530,7 @@ public:
     bool ReadByte(uint8& OutByte) { return Read(OutByte); }
 
 	/// Access the underlying archive in order to write custom data directly.
-	FArchive* GetUnderlyingArchive() const { return Ar; }
+	FArchive* GetUnderlyingArchive() const { return SPUDAr; }
 
 };
 


### PR DESCRIPTION
The use of FArchive Ar  in SpudState caused a shadowing issue with parameters in UObject methods.
Renamed this to SPUDAr to resolve.

The template definitions in SpudPorpertyUtil caused an duplicate symbol issue, by wrapping them in an un-named namespace this was able to be resolved.