### PR TITLE
Expose `ISpudObject` members to both C++ and BP

### DIFF
--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -533,7 +533,7 @@ void USpudState::DestroyActor(const FSpudDestroyedLevelActor& DestroyedActor, UL
 bool USpudState::ShouldRespawnRuntimeActor(const AActor* Actor) const
 {
 	ESpudRespawnMode RespawnMode = ESpudRespawnMode::Default;
-	if (Cast<ISpudObject>(Actor))
+	if (Actor->Implements<USpudObject>())
 	{
 		RespawnMode = ISpudObject::Execute_GetSpudRespawnMode(Actor);
 	}
@@ -565,7 +565,7 @@ bool USpudState::ShouldActorBeRespawnedOnRestore(AActor* Actor) const
 
 bool USpudState::ShouldActorTransformBeRestored(AActor* Actor) const
 {
-	if (Cast<ISpudObject>(Actor))
+	if (Actor->Implements<USpudObject>())
 	{
 		return ISpudObject::Execute_ShouldRestoreTransform(Actor);
 	}
@@ -575,7 +575,7 @@ bool USpudState::ShouldActorTransformBeRestored(AActor* Actor) const
 
 bool USpudState::ShouldActorVelocityBeRestored(AActor* Actor) const
 {
-	if (Cast<ISpudObject>(Actor))
+	if (Actor->Implements<USpudObject>())
 	{
 		return ISpudObject::Execute_ShouldRestoreVelocity(Actor);
 	}

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -567,7 +567,7 @@ bool USpudState::ShouldActorTransformBeRestored(AActor* Actor) const
 {
 	if (Actor->Implements<USpudObject>())
 	{
-		return ISpudObject::Execute_ShouldRestoreTransform(Actor);
+		return !ISpudObject::Execute_ShouldSkipRestoreTransform(Actor);
 	}
 	// Assume true
 	return true;
@@ -577,7 +577,7 @@ bool USpudState::ShouldActorVelocityBeRestored(AActor* Actor) const
 {
 	if (Actor->Implements<USpudObject>())
 	{
-		return ISpudObject::Execute_ShouldRestoreVelocity(Actor);
+		return !ISpudObject::Execute_ShouldSkipRestoreVelocity(Actor);
 	}
 	// Assume true
 	return true;

--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -533,10 +533,9 @@ void USpudState::DestroyActor(const FSpudDestroyedLevelActor& DestroyedActor, UL
 bool USpudState::ShouldRespawnRuntimeActor(const AActor* Actor) const
 {
 	ESpudRespawnMode RespawnMode = ESpudRespawnMode::Default;
-	// I know this cast style only supports C++ not Blueprints, but this method can only be defined in C++ anyway
-	if (auto IObj = Cast<ISpudObject>(Actor))
+	if (Cast<ISpudObject>(Actor))
 	{
-		RespawnMode = IObj->GetSpudRespawnMode();
+		RespawnMode = ISpudObject::Execute_GetSpudRespawnMode(Actor);
 	}
 
 	switch (RespawnMode)
@@ -566,10 +565,9 @@ bool USpudState::ShouldActorBeRespawnedOnRestore(AActor* Actor) const
 
 bool USpudState::ShouldActorTransformBeRestored(AActor* Actor) const
 {
-	// I know this cast style only supports C++ not Blueprints, but this method can only be defined in C++ anyway
-	if (auto IObj = Cast<ISpudObject>(Actor))
+	if (Cast<ISpudObject>(Actor))
 	{
-		return IObj->ShouldRestoreTransform();
+		return ISpudObject::Execute_ShouldRestoreTransform(Actor);
 	}
 	// Assume true
 	return true;
@@ -577,10 +575,9 @@ bool USpudState::ShouldActorTransformBeRestored(AActor* Actor) const
 
 bool USpudState::ShouldActorVelocityBeRestored(AActor* Actor) const
 {
-	// I know this cast style only supports C++ not Blueprints, but this method can only be defined in C++ anyway
-	if (auto IObj = Cast<ISpudObject>(Actor))
+	if (Cast<ISpudObject>(Actor))
 	{
-		return IObj->ShouldRestoreVelocity();
+		return ISpudObject::Execute_ShouldRestoreVelocity(Actor);
 	}
 	// Assume true
 	return true;

--- a/Source/SPUD/Public/ISpudObject.h
+++ b/Source/SPUD/Public/ISpudObject.h
@@ -28,6 +28,11 @@ class SPUD_API ISpudObject
 	GENERATED_BODY()
 
 public:
+
+	// Note: in order to support pure Blueprint overrides on behaviour customisation methods, all overrideable
+	// methods MUST have default return state of the zero-filled data. No default implementations that return "true" for example
+	// This is because a pure Blueprint override will not pick up the C++ implementation, because it's an interface, not a base class.
+	
 	/// Return whether this object should be respawned on load if it was detected as a runtime-created object
 	/// The default is to respawn all runtime objects except for Pawns, GameModes, GameStates, PlayerStates and Characters which are assumed to be created automatically.
 	/// You can override this if you want this for things like player pawns, game modes which are marked as runtime created, but
@@ -35,18 +40,18 @@ public:
 	/// Instead these objects will be identified by their names, much like level objects, and you should ensure that
 	/// they always have the same names between save & load. 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD Interface")
-  ESpudRespawnMode GetSpudRespawnMode() const; virtual ESpudRespawnMode GetSpudRespawnMode_Implementation() const { return ESpudRespawnMode::Default; }
+	ESpudRespawnMode GetSpudRespawnMode() const; virtual ESpudRespawnMode GetSpudRespawnMode_Implementation() const { return ESpudRespawnMode::Default; }
 
-	/// Return whether this object should restore its transform from the save data, if it's Movable
-	/// You can override this to false if you want this object to always retain its level location on restore.
+	/// Return whether this object should skip the restoration of its transform from the save data, if it's Movable.
+	/// You can override this to true if you want this object to always retain its level location on restore.
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD Interface")
-	bool ShouldRestoreTransform() const; virtual bool ShouldRestoreTransform_Implementation() const { return true; }
+	bool ShouldSkipRestoreTransform() const; virtual bool ShouldSkipRestoreTransform_Implementation() const { return false; }
 
-	/// Return whether this object should restore its velocity from the save data. Only applies if it's Movable, has opted
+	/// Return whether this object should skip restoring its velocity from the save data. Only applies if it's Movable, has opted
 	/// in to restoring transform, and has either physics sim enabled, or a movement component.
-	/// You can override this to false if you want this object to manage its own velocity on load.
+	/// You can override this to true if you want this object to manage its own velocity on load.
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD Interface")
-	bool ShouldRestoreVelocity() const; virtual bool ShouldRestoreVelocity_Implementation() const { return true; }
+	bool ShouldSkipRestoreVelocity() const; virtual bool ShouldSkipRestoreVelocity_Implementation() const { return false; }
 };
 
 UINTERFACE(MinimalAPI)

--- a/Source/SPUD/Public/ISpudObject.h
+++ b/Source/SPUD/Public/ISpudObject.h
@@ -11,6 +11,7 @@ class USpudObject : public UInterface
 	GENERATED_BODY()
 };
 
+UENUM(BlueprintType)
 enum class ESpudRespawnMode : uint8
 {
 	Default UMETA(DisplayName="Default behaviour (based on class)"),
@@ -33,21 +34,20 @@ public:
 	/// are created automatically at level start so should not be created by the load process.
 	/// Instead these objects will be identified by their names, much like level objects, and you should ensure that
 	/// they always have the same names between save & load. 
-	/// This can only be changed in C++ implementations and not Blueprints since they don't support this default impl
-    virtual ESpudRespawnMode GetSpudRespawnMode() const { return ESpudRespawnMode::Default; }
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD Interface")
+  ESpudRespawnMode GetSpudRespawnMode() const; virtual ESpudRespawnMode GetSpudRespawnMode_Implementation() const { return ESpudRespawnMode::Default; }
 
 	/// Return whether this object should restore its transform from the save data, if it's Movable
 	/// You can override this to false if you want this object to always retain its level location on restore.
-	/// This can only be changed in C++ implementations and not Blueprints since they don't support this default impl
-	virtual bool ShouldRestoreTransform() const { return true; }
-	
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD Interface")
+	bool ShouldRestoreTransform() const; virtual bool ShouldRestoreTransform_Implementation() const { return true; }
+
 	/// Return whether this object should restore its velocity from the save data. Only applies if it's Movable, has opted
 	/// in to restoring transform, and has either physics sim enabled, or a movement component.
 	/// You can override this to false if you want this object to manage its own velocity on load.
-	/// This can only be changed in C++ implementations and not Blueprints since they don't support this default impl
-	virtual bool ShouldRestoreVelocity() const { return true; }
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "SPUD Interface")
+	bool ShouldRestoreVelocity() const; virtual bool ShouldRestoreVelocity_Implementation() const { return true; }
 };
-
 
 UINTERFACE(MinimalAPI)
 class USpudObjectCallback : public UInterface


### PR DESCRIPTION
Change the interface prototypes in `ISpudObject` to allow overriding in both BP and C++. BP can override via the normal interface override process and interface methods will just show up in the sidebar as expected. 
![image](https://user-images.githubusercontent.com/700435/141658740-f68c29bb-a297-40cf-9788-949410cc7ee9.png)

C++ can override `*_Implementation` methods.

Change existing calls to the interface functions in C++ to use the prescribed entry point that covers both C++ and BP use cases.

I ran the 4 integration tests and tested this in the SPUDExamples project to make sure everything worked out as expected. It behaves as expected.