### PR TITLE
Fix clang build errors

### DIFF
--- a/Source/SPUD/Private/SpudData.cpp
+++ b/Source/SPUD/Private/SpudData.cpp
@@ -1263,7 +1263,7 @@ bool FSpudSaveData::WriteAndReleaseLevelData(const FString& LevelName, const FSt
 		if (LevelData->Status == LDS_Loaded ||
 			// If we've queued a background write & unload but this is now requesting a blocking write, we
 			// should upgrade it and do it NOW. When the status is changed to LDS_Unloaded the background worker will ignore it
-			LevelData->Status == LDS_BackgroundWriteAndUnload && bBlocking)
+			(LevelData->Status == LDS_BackgroundWriteAndUnload && bBlocking))
 		{
 			if (bBlocking)
 			{

--- a/Source/SPUDTest/Private/SpudTest.cpp
+++ b/Source/SPUDTest/Private/SpudTest.cpp
@@ -11,7 +11,7 @@ void PopulateAllTypes(T& Obj)
 	Obj.UInt8Val = 245;
 	Obj.UInt16Val = 61234;
 	Obj.UInt32Val = 4123456789;
-	Obj.UInt64Val = 18123456789123456789;
+	Obj.UInt64Val = 18123456789123456789ull;
 	Obj.Int8Val = -123;
 	Obj.Int16Val = -32123;
 	Obj.Int32Val = -2112345678;


### PR DESCRIPTION
This fixes two issues I encountered when trying to build for Linux with clang:

- error: integer literal is too large to be represented in a signed integer type, interpreting as unsigned [-Werror,-Wimplicitly-unsigned-literal]
- error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]

The fixes are thankfully rather simple.