### PR TITLE
Support for FText and FMap property

### DIFF
--- a/Source/SPUD/Public/SpudData.h
+++ b/Source/SPUD/Public/SpudData.h
@@ -88,6 +88,8 @@ enum SPUD_API ESpudStorageType // (stored as uint16 but not using enum class to 
 	ESST_String = 30,
 	ESST_Name = 31,
 	ESST_Text = 32,
+	// Max has to be higher than any other type. Used to serialize 2 types in FMap.
+	ESST_Max = 64,
 
 	/// Unknown is a placeholder fallback
 	ESST_Unknown = 0x0F00,

--- a/Source/SPUD/Public/SpudPropertyUtil.h
+++ b/Source/SPUD/Public/SpudPropertyUtil.h
@@ -224,6 +224,15 @@ public:
 	                               TArray<uint32>& PropertyOffsets,
 	                               FSpudClassMetadata& Meta,
 	                               FMemoryWriter& Out);
+	static void StoreMapProperty(FMapProperty* MProp,
+	                             const UObject* RootObject,
+	                             uint32 PrefixID,
+	                             const void* ContainerPtr,
+	                             int Depth,
+	                             TSharedPtr<FSpudClassDef> ClassDef,
+	                             TArray<uint32>& PropertyOffsets,
+	                             FSpudClassMetadata& Meta,
+	                             FMemoryWriter& Out);
 	static void StoreContainerProperty(FProperty* Property,
 	                                   const UObject* RootObject,
 	                                   uint32 PrefixID,
@@ -248,6 +257,11 @@ public:
 	                                 const RuntimeObjectMap* RuntimeObjects,
 	                                 const FSpudClassMetadata& Meta,
 	                                 int Depth, FMemoryReader& DataIn);
+	static void RestoreMapProperty(UObject* RootObject, FMapProperty* const AProp, void* ContainerPtr,
+	                               const FSpudPropertyDef& StoredProperty,
+	                               const RuntimeObjectMap* RuntimeObjects,
+	                               const FSpudClassMetadata& Meta,
+	                               int Depth, FMemoryReader& DataIn);
 	static void RestoreContainerProperty(UObject* RootObject, FProperty* const Property,
 	                                     void* ContainerPtr, const FSpudPropertyDef& StoredProperty,
 	                                     const RuntimeObjectMap* RuntimeObjects,
@@ -263,6 +277,7 @@ public:
 
 protected:
 	static bool IsValidArrayType(FArrayProperty* AProp);
+	static bool IsValidMapType(FMapProperty* MProp);
 	/// General recursive visitation of properties, returns false to early-out, object/container can be null
 	static bool VisitPersistentProperties(UObject* RootObject, const UStruct* Definition, uint32 PrefixID,
 	                                      void* ContainerPtr, bool IsChildOfSaveGame, int Depth,

--- a/Source/SPUDTest/Private/SpudTest.cpp
+++ b/Source/SPUDTest/Private/SpudTest.cpp
@@ -91,6 +91,15 @@ void PopulateAllTypes(T& Obj)
 	Obj.StringArray.Add("Yeah, best crack on eh?");	
 	Obj.TextArray.Add(FText::FromString("TextOne"));
 	Obj.TextArray.Add(FText::FromString("TextTwo"));
+
+	Obj.IntMap.Add(136, 137);
+	Obj.IntMap.Add(-31913, -31914);
+	Obj.FloatMap.Add(-3456.236, -3457.236);
+	Obj.FloatMap.Add(-1.99, -2.99);
+	Obj.IntFloatMap.Add(136, 3.99);
+	Obj.IntFloatMap.Add(138, -4.99);
+	Obj.StringVectorMap.Add("Test data is super boring to write!", FVector(1, 2, 3));
+	Obj.StringVectorMap.Add("I know, right?", FVector(3, 4, 5));
 }
 
 template<typename T>
@@ -101,7 +110,19 @@ void CheckArray(FAutomationTestBase* Test, const FString& Prefix, const TArray<T
 	{
 		Test->TestEqual(FString::Printf(TEXT("%sItem %d should match"), *Prefix, i), Actual[i], Expected[i]);
 	}
-	
+
+}
+
+template<typename K, typename V>
+void CheckMap(FAutomationTestBase* Test, const FString& Prefix, const TMap<K, V>& Actual, const TMap<K, V>& Expected)
+{
+	Test->TestEqual(Prefix + "Map Length should match", Actual.Num(), Expected.Num());
+	int i = 0;
+	for (auto& Elem : Actual)
+	{
+		Test->TestEqual(FString::Printf(TEXT("%sItem %d should match"), *Prefix, i), Elem.Value, Expected.FindRef(Elem.Key));
+		i++;
+	}
 }
 
 template<typename T>
@@ -172,6 +193,10 @@ void CheckAllTypes(FAutomationTestBase* Test, const FString& Prefix, const T& Ac
 	Test->TestEqual(Prefix + "TextArray 0 should match", Actual.TextArray[0].ToString(), Expected.TextArray[0].ToString());
 	Test->TestEqual(Prefix + "TextArray 1 should match", Actual.TextArray[1].ToString(), Expected.TextArray[1].ToString());
 
+	CheckMap(Test, Prefix + "IntMap|", Actual.IntMap, Expected.IntMap);
+	CheckMap(Test, Prefix + "FloatMap|", Actual.FloatMap, Expected.FloatMap);
+	CheckMap(Test, Prefix + "IntFloatMap|", Actual.IntFloatMap, Expected.IntFloatMap);
+	CheckMap(Test, Prefix + "StringVectorMap|", Actual.StringVectorMap, Expected.StringVectorMap);
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestBasicAllTypes, "SPUDTest.BasicAllTypes",

--- a/Source/SPUDTest/Private/TestSaveObject.h
+++ b/Source/SPUDTest/Private/TestSaveObject.h
@@ -130,6 +130,16 @@ public:
 	TArray<FText> TextArray;
 
 	// Arrays of custom structs or UObjects are not supported yet
+
+	// Maps of the above
+	UPROPERTY(SaveGame)
+	TMap<int, int> IntMap;
+	UPROPERTY(SaveGame)
+	TMap<float, float> FloatMap;
+	UPROPERTY(SaveGame)
+	TMap<int, float> IntFloatMap;
+	UPROPERTY(SaveGame)
+	TMap<FString, FVector> StringVectorMap;
 };
 
 // Test 2-level nesting
@@ -244,6 +254,16 @@ public:
 	TArray<FString> StringArray;
 	UPROPERTY(SaveGame)
 	TArray<FText> TextArray;
+
+	// Maps of the above
+	UPROPERTY(SaveGame)
+	TMap<int, int> IntMap;
+	UPROPERTY(SaveGame)
+	TMap<float, float> FloatMap;
+	UPROPERTY(SaveGame)
+	TMap<int, float> IntFloatMap;
+	UPROPERTY(SaveGame)
+	TMap<FString, FVector> StringVectorMap;
 };
 
 


### PR DESCRIPTION
I tried to add support for FText which should be just copy of FName.

Second is support for FMap serialization. I tried to do it similar to FArray so there is a lot copy/paste and that it will fit into your systems without any major changes.
I have to figure out how to save property type unique which will contain both key type and value type. I added ESST_Max = 64 and calculate it as "KeyType * ESST_Max + ValueType". I think it gives enough space for more ESST_ types and still be unique for any type of key/value types combination.

Also added tests for FText and some TMap types combination.