### PR TITLE
Set the Outer for newly constructed nested UObjects

### DIFF
--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -549,7 +549,7 @@ FString SpudPropertyUtil::ReadActorRefPropertyData(FObjectProperty* OProp, void*
 
 FString SpudPropertyUtil::ReadNestedUObjectPropertyData(FObjectProperty* OProp, void* Data,
 														const RuntimeObjectMap* RuntimeObjects,
-														ULevel* Level, const FSpudClassMetadata& Meta,
+														ULevel* Level, UObject* Outer, const FSpudClassMetadata& Meta,
 														FArchive& In)
 {
 	uint32 ClassID;
@@ -579,7 +579,7 @@ FString SpudPropertyUtil::ReadNestedUObjectPropertyData(FObjectProperty* OProp, 
 				return Ret;
 			}
 
-			Object = NewObject<UObject>(OProp->GetOwnerUObject(), Class);
+			Object = NewObject<UObject>(Outer, Class);
 			OProp->SetObjectPropertyValue(Data, Object);
 			Ret = ClassName;
 		}
@@ -627,7 +627,7 @@ FString SpudPropertyUtil::ReadSubclassOfPropertyData(FObjectProperty* OProp, voi
 
 
 bool SpudPropertyUtil::TryReadUObjectPropertyData(FProperty* Prop, void* Data,
-                                                  const FSpudPropertyDef& StoredProperty, const RuntimeObjectMap* RuntimeObjects, ULevel* Level,
+                                                  const FSpudPropertyDef& StoredProperty, const RuntimeObjectMap* RuntimeObjects, ULevel* Level, UObject* Outer,
                                                   const FSpudClassMetadata& Meta, int Depth, FArchive& In)
 {
 	auto OProp = CastField<FObjectProperty>(Prop);
@@ -647,7 +647,7 @@ bool SpudPropertyUtil::TryReadUObjectPropertyData(FProperty* Prop, void* Data,
 		}
 		else
 		{
-			const FString Val = ReadNestedUObjectPropertyData(OProp, Data, RuntimeObjects, Level, Meta, In);
+			const FString Val = ReadNestedUObjectPropertyData(OProp, Data, RuntimeObjects, Level, Outer, Meta, In);
 			UE_LOG(LogSpudProps, Verbose, TEXT("%s = %s"), *GetLogPrefix(Prop, Depth), *Val);
 		}
 		return true;
@@ -858,7 +858,7 @@ void SpudPropertyUtil::RestoreContainerProperty(UObject* RootObject, FProperty* 
 			ULevel* Level = nullptr;
 			if (auto Actor = Cast<AActor>(RootObject))
 				Level = Actor->GetLevel();
-			bUpdateOK = TryReadUObjectPropertyData(Property, DataPtr, StoredProperty, RuntimeObjects, Level, Meta, Depth, DataIn);
+			bUpdateOK = TryReadUObjectPropertyData(Property, DataPtr, StoredProperty, RuntimeObjects, Level, RootObject, Meta, Depth, DataIn);
 		}
 		
 	}

--- a/Source/SPUD/Public/SpudPropertyUtil.h
+++ b/Source/SPUD/Public/SpudPropertyUtil.h
@@ -380,12 +380,12 @@ protected:
 	                                    int Depth, FArchive& In);
 	static FString ReadActorRefPropertyData(::FObjectProperty* OProp, void* Data, const RuntimeObjectMap* RuntimeObjects, ULevel* Level, FArchive& In);
 	static FString ReadNestedUObjectPropertyData(::FObjectProperty* OProp, void* Data, const RuntimeObjectMap* RuntimeObjects,
-		ULevel* Level, const FSpudClassMetadata& Meta, FArchive& In);
+		ULevel* Level, UObject* Outer, const FSpudClassMetadata& Meta, FArchive& In);
 	static FString ReadSubclassOfPropertyData(::FObjectProperty* OProp, void* Data, const RuntimeObjectMap* RuntimeObjects,
 		ULevel* Level, const FSpudClassMetadata& Meta, FArchive& In);
 	static bool TryReadUObjectPropertyData(::FProperty* Prop, void* Data, const ::FSpudPropertyDef& StoredProperty,
 	                                        const RuntimeObjectMap* RuntimeObjects,
-	                                        ULevel* Level, const FSpudClassMetadata& Meta, int Depth, FArchive& In);
+	                                        ULevel* Level, UObject* Outer, const FSpudClassMetadata& Meta, int Depth, FArchive& In);
 
 public:
 


### PR DESCRIPTION
During testing, I noticed that restored nested UObjects were being created with their Outer set to the UClass of their containing UObject.  Digging deeper, I found that this was being caused by the call to OProp->GetOwnerUObject().

My 'fix' isn't the nicest, but I have been unable to find a way to get back from the given parameters to the containing RootObject.

It could be neater to leave the Outer as nullptr, which will create the object in the transient package, but it feels more 'correct' to set it to the parent UObject.