### PR TITLE
Fix nested uobject

### DIFF
--- a/Source/SPUD/Private/SpudState.cpp
+++ b/Source/SPUD/Private/SpudState.cpp
@@ -454,7 +454,7 @@ void USpudState::RestoreLevel(ULevel* Level)
 	// Destroy actors in level but missing from save state
 	for (auto&& DestroyedActor : LevelData->DestroyedActors.Values)
 	{
-		DestroyActor(DestroyedActor, Level);			
+		DestroyActor(*DestroyedActor, Level);			
 	}
 	UE_LOG(LogSpudState, Verbose, TEXT("RESTORE level %s - Complete"), *LevelName);
 
@@ -753,7 +753,7 @@ void USpudState::RestoreObjectProperties(UObject* Obj, FMemoryReader& In, const 
 	const auto ClassDef = Meta.GetClassDef(ClassName);
 	if (!ClassDef)
 	{
-		UE_LOG(LogSpudState, Error, TEXT("Unable to find ClassDef for: %s %s"), *SpudPropertyUtil::GetClassName(Obj));
+		UE_LOG(LogSpudState, Error, TEXT("Unable to find ClassDef for: %s"), *SpudPropertyUtil::GetClassName(Obj));
 		return;
 	}
 

--- a/Source/SPUDTest/Private/SpudTest.cpp
+++ b/Source/SPUDTest/Private/SpudTest.cpp
@@ -307,3 +307,32 @@ bool FTestCustomData::RunTest(const FString& Parameters)
 
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTestNestedObject, "SPUDTest.NestedObject",
+	EAutomationTestFlags::EditorContext |
+	EAutomationTestFlags::ClientContext |
+	EAutomationTestFlags::ProductFilter)
+
+bool FTestNestedObject::RunTest(const FString& Parameters)
+{
+	auto SavedObj = NewObject<UTestSaveObjectParent>();
+	SavedObj->UObjectVal1 = NewObject<UTestNestedChild1>();
+	SavedObj->UObjectVal2 = NewObject<UTestNestedChild2>();
+	SavedObj->UObjectVal3 = NewObject<UTestNestedChild3>();
+	SavedObj->UObjectVal4 = NewObject<UTestNestedChild4>();
+	SavedObj->UObjectVal5 = NewObject<UTestNestedChild5>();
+
+	auto State = NewObject<USpudState>();
+	State->StoreGlobalObject(SavedObj, "TestObject");
+
+	auto LoadedObj = NewObject<UTestSaveObjectParent>();
+	State->RestoreGlobalObject(LoadedObj, "TestObject");
+
+	TestNotNull("UObject1 shouldn't be null", LoadedObj->UObjectVal1);
+	TestNotNull("UObject2 shouldn't be null", LoadedObj->UObjectVal2);
+	TestNotNull("UObject3 shouldn't be null", LoadedObj->UObjectVal3);
+	TestNotNull("UObject4 shouldn't be null", LoadedObj->UObjectVal4);
+	TestNotNull("UObject5 shouldn't be null", LoadedObj->UObjectVal5);
+
+	return true;
+}

--- a/Source/SPUDTest/Private/TestSaveObject.h
+++ b/Source/SPUDTest/Private/TestSaveObject.h
@@ -287,3 +287,71 @@ public:
 	virtual void SpudStoreCustomData_Implementation(const USpudState* State, USpudStateCustomData* CustomData) override;
 	virtual void SpudRestoreCustomData_Implementation(USpudState* State, USpudStateCustomData* CustomData) override;
 };
+
+
+/// Simple children UObjects and parent
+UCLASS()
+class SPUDTEST_API UTestNestedChild1 : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(SaveGame)
+	FString NestedStringVal1;
+};
+
+UCLASS()
+class SPUDTEST_API UTestNestedChild2 : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(SaveGame)
+	FString NestedStringVal2;
+};
+
+UCLASS()
+class SPUDTEST_API UTestNestedChild3 : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(SaveGame)
+	FString NestedStringVal3;
+};
+
+UCLASS()
+class SPUDTEST_API UTestNestedChild4 : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(SaveGame)
+	FString NestedStringVal4;
+};
+
+UCLASS()
+class SPUDTEST_API UTestNestedChild5 : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(SaveGame)
+	FString NestedStringVal5;
+};
+
+UCLASS()
+class SPUDTEST_API UTestSaveObjectParent : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(SaveGame)
+	UTestNestedChild1* UObjectVal1;
+
+	UPROPERTY(SaveGame)
+	UTestNestedChild2* UObjectVal2;
+
+	UPROPERTY(SaveGame)
+	UTestNestedChild3* UObjectVal3;
+
+	UPROPERTY(SaveGame)
+	UTestNestedChild4* UObjectVal4;
+
+	UPROPERTY(SaveGame)
+	UTestNestedChild5* UObjectVal5;
+};


### PR DESCRIPTION
Hi, I found problem what I believe are nested UObjects, but it should be in your master without any my changes so I want to let you know.
I split pull request into 2 commits:
- First is just added test that create Parent and 5 children classes. It is not nice code but I need all 6 classes different and this do it's job.
- Second commit is potential fix.

### Repro with only first commit:
- Run "SPUDTest.NestedObject" test in Session Frontend. It should fail that it can't restore objects.
- Or better is to start editor with "-stompmalloc" parameter to enable stomp allocator which checks whether you write to invalid pointer and stop debugger much sooner which helps me very much to find problem.

### Context:
Reason why it failed is connected to reference to value in **FSpudClassMetadata::ClassDefinitions** saved in **USpudState::StoreObjectProperties** in **auto& ClassDef** variable. And that when adding 5th element into **ClassDefinitions** in **FSpudClassMetadata::FindOrAddClassDef** the array is resized. Don't know whether resize after 4th element is Unreal default or some platform specific.

### Please check this callstack:
`USpudState::StoreObjectProperties(UObject * Obj, unsigned int PrefixID, TArray<unsigned int,TSizedDefaultAllocator<32>> & PropOffsets, FSpudClassMetadata & Meta, FMemoryWriter & Out, int StartDepth) Line 407	C++
USpudState::StorePropertyVisitor::StoreNestedUObjectIfNeeded(UObject * RootObject, FProperty * Property, unsigned int CurrentPrefixID, void * ContainerPtr, int Depth) Line 116	C++
USpudState::StorePropertyVisitor::VisitProperty(UObject * RootObject, FProperty * Property, unsigned int CurrentPrefixID, void * ContainerPtr, int Depth) Line 84	C++
SpudPropertyUtil::VisitPersistentProperties(UObject * RootObject, const UStruct * Definition, unsigned int PrefixID, void * ContainerPtr, bool IsChildOfSaveGame, int Depth, SpudPropertyUtil::PropertyVisitor & Visitor) Line 304	C++
SpudPropertyUtil::VisitPersistentProperties(UObject * RootObject, SpudPropertyUtil::PropertyVisitor & Visitor, int StartDepth) Line 277	C++
USpudState::StoreObjectProperties(UObject * Obj, unsigned int PrefixID, TArray<unsigned int,TSizedDefaultAllocator<32>> & PropOffsets, FSpudClassMetadata & Meta, FMemoryWriter & Out, int StartDepth) Line 407	C++
USpudState::StoreObjectProperties(UObject * Obj, FSpudPropertyData & Properties, FSpudClassMetadata & Meta, int StartDepth) Line 395	C++
USpudState::StoreGlobalObject(UObject * Obj, FSpudNamedObjectData * Data) Line 372	C++
USpudState::StoreGlobalObject(UObject * Obj, const FString & ID) Line 355	C++
FTestNestedObject::RunTest(const FString & Parameters) Line 312	C++
`

**USpudState::StoreObjectProperties** is there twice so **auto& ClassDef** is invalid when second call of this function resize  ClassDefinitions array.

I don't know whether there is better solution than just have array of pointers and create items dynamically instead of array of instances.
So feel free to just use or rewrite just the test. I hope it will help.