### PR TITLE
Fix crash in timer manager if the world is unloaded

### DIFF
--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -371,14 +371,17 @@ void USpudSubsystem::HandleLevelLoaded(FName LevelName)
 	GetActiveState()->PreLoadLevelData(LevelName.ToString());
 
 	AsyncTask(ENamedThreads::GameThread, [this, LevelName]()
+	{
+		// But also add a slight delay so we get a tick in between so physics works
+		FTimerHandle H;
+		if (UWorld* World = GetWorld())
 		{
-			// But also add a slight delay so we get a tick in between so physics works
-			FTimerHandle H;
-			GetWorld()->GetTimerManager().SetTimer(H, [this, LevelName]()
-				{
-					PostLoadStreamLevelGameThread(LevelName);
-				}, 0.01, false);
-		});
+			World->GetTimerManager().SetTimer(H, [this, LevelName]()
+			{
+				PostLoadStreamLevelGameThread(LevelName);
+			}, 0.01, false);
+		}
+	});
 }
 
 void USpudSubsystem::HandleLevelUnloaded(ULevel* Level)


### PR DESCRIPTION
The world can get unloaded while the timer triggers especially during world composition