### PR TITLE
Add RestartAfterLevelLoad state, to handle delayed NewGame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Plugins/*/Intermediate/*
 # Cache files for the editor to use
 DerivedDataCache/*
 
+/.vs

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -42,7 +42,9 @@ enum class ESpudSystemState : uint8
 	/// Currently loading a save game, cannot be interrupted
     LoadingGame,
 	/// Currently saving a game, cannot be interrupted
-    SavingGame
+    SavingGame,
+	// Will switch to RunningIdle after a level is loaded.
+	RestartAfterLevelLoad,
 };
 
 UENUM(BlueprintType)


### PR DESCRIPTION
NewGame(bAfterLevelLoad = true) doesn't work as intended. OnPreLoadMap will save the current world if state is RunningIdle, and OnPostLoadMap will try to restore it.
