### PR TITLE
No longer crashes when exiting the game from a world partitioned level

### DIFF
--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -52,6 +52,30 @@ void USpudSubsystem::Deinitialize()
 	FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(OnPostLoadMapHandle);
 	FCoreUObjectDelegates::PreLoadMap.Remove(OnPreLoadMapHandle);
 	FWorldDelegates::OnSeamlessTravelTransition.Remove(OnSeamlessTravelHandle);
+
+    // Tell all visible levels to save themselves, as we're shutting down
+    for (auto It = MonitoredStreamingLevels.CreateIterator(); It; ++It)
+    {
+        ULevelStreaming* const Level = It.Key();
+        if (ensure(Level))
+        {
+            USpudStreamingLevelWrapper* const Wrapper = It.Value();
+
+            if (Level->IsLevelVisible())
+            {
+                UE_LOG(LogSpudSubsystem, Verbose, TEXT("Firing OnLevelHidden for streaming level as shutting down: %s"), *GetNameSafe(Level));
+
+                // We need to fire this now in order to ensure it's state gets saved
+                // before USpudSubsystem is destroyed
+                Wrapper->OnLevelHidden();
+            }
+
+            // Remove callbacks, as we've already processed everything
+            Level->OnLevelShown.RemoveAll(Wrapper);
+            Level->OnLevelHidden.RemoveAll(Wrapper);
+            It.RemoveCurrent();
+        }
+    }
 }
 
 
@@ -1244,8 +1268,12 @@ void USpudStreamingLevelWrapper::OnLevelShown()
 	if (level)
 	{
 		UE_LOG(LogSpudSubsystem, Verbose, TEXT("Level shown: %s"), *USpudState::GetLevelName(level));
+		
 		auto spud = UGameInstance::GetSubsystem<USpudSubsystem>(GetWorld()->GetGameInstance());
-		spud->HandleLevelLoaded(level);
+	    if (ensureMsgf(spud, TEXT("Unable to find SpudSubsystem, so cannot load the state of level: %s"), *USpudState::GetLevelName(level)))
+	    {
+	        spud->HandleLevelLoaded(level);
+	    }
 	}
 	else
 		UE_LOG(LogSpudSubsystem, Verbose, TEXT("No loaded level"));
@@ -1258,9 +1286,15 @@ void USpudStreamingLevelWrapper::OnLevelHidden()
 	{
 		const auto levelName = USpudState::GetLevelName(level);
 		UE_LOG(LogSpudSubsystem, Verbose, TEXT("Level hidden: %s"), *levelName);
-		auto spud = UGameInstance::GetSubsystem<USpudSubsystem>(GetWorld()->GetGameInstance());
-		spud->PreUnloadStreamingLevel.Broadcast(FName(levelName));
-		spud->HandleLevelUnloaded(level);
+		
+		// We no longer crash, but we still need to know when this happens, as we really should be
+	    // storing the state of the unloaded level
+	    auto spud = UGameInstance::GetSubsystem<USpudSubsystem>(GetWorld()->GetGameInstance());
+	    if (ensureMsgf(spud, TEXT("Unable to find SpudSubsystem, so cannot save the state of level: %s"), *levelName))
+	    {
+	        spud->PreUnloadStreamingLevel.Broadcast(FName(levelName));
+	        spud->HandleLevelUnloaded(level);
+	    }
 	}
 	else
 		UE_LOG(LogSpudSubsystem, Verbose, TEXT("No loaded level"));


### PR DESCRIPTION
When the player quits to desktop from a world partitioned world, the levels start to receive the `OnLevelHidden` callback.

Midway through processing all of the levels, `USpudSubsystem::Deinitialize()` gets called, and then all GameInstance subsystems, including `USpudSubsystem`, are removed from the GameInstance.

However, the world continues to process the `OnLevelHidden` callbacks, but they are now not able to retrieve the `USpudSubsystem` in order to save the level state, and this causes a crash.

I've resolved this a number of ways - first, the `OnLevelHidden` and `OnLevelShown` methods now check for a valid `USpudSubsystem`, and throw an ensure with an explanation if it's not valid.

Secondly, when `USpudSubsystem::Deinitialize()` is called, I'm clearing out the list of monitored streaming levels, and manually calling `OnLevelHidden` on those that are still visible, so that their state is stored before the subsystem is destroyed.