### PR TITLE
Fix null parent Level for Actor references nested in components

### DIFF
--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -1030,7 +1030,10 @@ void SpudPropertyUtil::RestoreContainerProperty(UObject* RootObject, FProperty* 
 				{
 					if (UActorComponent* ActorComponentLevelCheck = Cast<UActorComponent>(RootObject))
 					{
-						Level = ActorComponentLevelCheck->GetOwner()->GetLevel();
+						if (IsValid(ActorComponentLevelCheck->GetOwner()->GetLevel()))
+						{
+							Level = ActorComponentLevelCheck->GetOwner()->GetLevel();
+						}
 					}
 				}
 				bUpdateOK = TryReadUObjectPropertyData(Property, DataPtr, StoredProperty, RuntimeObjects, Level, RootObject, Meta, Depth, DataIn);

--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -1023,7 +1023,16 @@ void SpudPropertyUtil::RestoreContainerProperty(UObject* RootObject, FProperty* 
 			
 				ULevel* Level = nullptr;
 				if (auto Actor = Cast<AActor>(RootObject))
+				{
 					Level = Actor->GetLevel();
+				}
+				if (!IsValid(Level))
+				{
+					if (UActorComponent* ActorComponentLevelCheck = Cast<UActorComponent>(RootObject))
+					{
+						Level = ActorComponentLevelCheck->GetOwner()->GetLevel();
+					}
+				}
 				bUpdateOK = TryReadUObjectPropertyData(Property, DataPtr, StoredProperty, RuntimeObjects, Level, RootObject, Meta, Depth, DataIn);
 			}
 		


### PR DESCRIPTION
When storing a reference to an actor within an actor component, that reference was lost upon reload because `Level` within `SpudPropertyUtil::RestoreContainerProperty` remained nullptr (seemingly).

With the attached fix, along with the actor component and actor reference both marked as `SaveGame`, the nested actor reference loads properly.

I'm not sure if this only affects level-placed actors whose reference was stored during play (and not during construction/initialization), but that was the condition I've tested.