### PR TITLE
Unreal 5.5 compile fix with explicit include of InstancedStruct

### DIFF
--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -5,6 +5,7 @@
 #include "InstancedStruct.h"
 #include "ISpudObject.h"
 #include "..\Public\SpudMemoryReaderWriter.h"
+#include "StructUtils/InstancedStruct.h"
 
 DEFINE_LOG_CATEGORY(LogSpudProps)
 

--- a/Source/SPUDTest/Private/TestSaveObject.h
+++ b/Source/SPUDTest/Private/TestSaveObject.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "InstancedStruct.h"
 #include "ISpudObject.h"
+#include "StructUtils/InstancedStruct.h"
 #include "UObject/Object.h"
 #include "TestSaveObject.generated.h"
 


### PR DESCRIPTION
Mandatory to compile in 5.5: fix with explicit inlcude of InstancedStruct