### PR TITLE
Add version detection macros to fix compilation errors in UE versions below 5.5

### DIFF
--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -2,10 +2,13 @@
 #include <limits>
 
 #include "EngineUtils.h"
-#include "InstancedStruct.h"
 #include "ISpudObject.h"
 #include "..\Public\SpudMemoryReaderWriter.h"
+#if ENGINE_MAJOR_VERSION==5&&ENGINE_MINOR_VERSION>=5
 #include "StructUtils/InstancedStruct.h"
+#else
+#include "InstancedStruct.h"
+#endif
 
 DEFINE_LOG_CATEGORY(LogSpudProps)
 

--- a/Source/SPUDTest/Private/TestSaveObject.h
+++ b/Source/SPUDTest/Private/TestSaveObject.h
@@ -3,9 +3,12 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "InstancedStruct.h"
 #include "ISpudObject.h"
+#if ENGINE_MAJOR_VERSION==5&&ENGINE_MINOR_VERSION>=5
 #include "StructUtils/InstancedStruct.h"
+#else
+#include "InstancedStruct.h"
+#endif
 #include "UObject/Object.h"
 #include "TestSaveObject.generated.h"
 


### PR DESCRIPTION
It appears that in version 5.5, they moved the namespace for InstancedStruct.h. I've added version detection macros to ensure backward compatibility.