### PR TITLE
new features and optimizations

### DIFF
--- a/Source/SPUD/Private/SpudPropertyUtil.cpp
+++ b/Source/SPUD/Private/SpudPropertyUtil.cpp
@@ -12,6 +12,15 @@
 
 DEFINE_LOG_CATEGORY(LogSpudProps)
 
+struct FCachedPersistentProperty
+{
+	FProperty* Property = nullptr;
+	FStructProperty* NestedStructProp = nullptr;
+	bool bIsInstancedStruct = false;
+};
+
+static TMap<TPair<const UStruct*, bool>, TArray<FCachedPersistentProperty>> PersistentPropertyCache;
+
 bool SpudPropertyUtil::ShouldPropertyBeIncluded(FProperty* Property, bool IsChildOfSaveGame)
 {
 	if (Property->HasAnyPropertyFlags(CPF_Deprecated))
@@ -305,73 +314,94 @@ bool SpudPropertyUtil::VisitPersistentProperties(UObject* RootObject, const UStr
                                                      void* ContainerPtr, bool IsChildOfSaveGame, int Depth,
                                                      PropertyVisitor& Visitor)
 {
-	// NOTE: RootObject and ContainerPtr can be null (when parsing just definitions without instances)
-	for (TFieldIterator<FProperty>PIT(Definition, EFieldIteratorFlags::IncludeSuper); PIT; ++PIT)
+	const auto CacheKey = MakeTuple(Definition, IsChildOfSaveGame);
+	auto CachedList = PersistentPropertyCache.Find(CacheKey);
+
+	if (!CachedList)
 	{
-		FProperty* Property = *PIT;
-
-		if (!ShouldPropertyBeIncluded(Property, IsChildOfSaveGame))
-			continue;
-
-		if (!IsPropertySupported(Property))
+		TArray<FCachedPersistentProperty> NewCache;
+		for (TFieldIterator<FProperty> PIT(Definition, EFieldIteratorFlags::IncludeSuper); PIT; ++PIT)
 		{
-			Visitor.UnsupportedProperty(RootObject, Property, PrefixID, Depth);
-			continue;
+			FProperty* Property = *PIT;
+
+			if (!ShouldPropertyBeIncluded(Property, IsChildOfSaveGame))
+				continue;
+
+			if (!IsPropertySupported(Property))
+			{
+				UE_LOG(LogSpudProps, Error, TEXT("Property %s/%s is marked for save but is an unsupported type, ignoring."),
+					*GetNameSafe(RootObject), *Property->GetName());
+				continue;
+			}
+
+			FCachedPersistentProperty Entry;
+			Entry.Property = Property;
+			Entry.NestedStructProp = nullptr;
+			Entry.bIsInstancedStruct = false;
+
+			if (const auto SProp = CastField<FStructProperty>(Property))
+			{
+				if (!IsBuiltInStructProperty(SProp))
+				{
+					Entry.NestedStructProp = SProp;
+					Entry.bIsInstancedStruct = SProp->Struct->IsChildOf(FInstancedStruct::StaticStruct());
+				}
+			}
+
+			NewCache.Add(Entry);
 		}
 
-		// Visitor can early-out
-		if (!Visitor.VisitProperty(RootObject, Property, PrefixID, ContainerPtr, Depth))
+		CachedList = &PersistentPropertyCache.Add(CacheKey, MoveTemp(NewCache));
+	}
+
+	// Copy to local — recursive calls for nested structs can Add() to the map,
+	// which may rehash and invalidate the CachedList pointer.
+	const auto LocalCache = *CachedList;
+
+	for (const auto& Entry : LocalCache)
+	{
+		if (!Visitor.VisitProperty(RootObject, Entry.Property, PrefixID, ContainerPtr, Depth))
 			return false;
 
-		// Now deal with cascading into nested structs (custom structs, not FVector etc)
-		if (const auto SProp = CastField<FStructProperty>(Property))
+		if (Entry.NestedStructProp)
 		{
-			if (!IsBuiltInStructProperty(SProp))
+			const UScriptStruct* StructDefinition = nullptr;
+			void* StructPtr = nullptr;
+
+			if (Entry.bIsInstancedStruct)
 			{
-				const UScriptStruct* StructDefinition = nullptr;
-				void* StructPtr = nullptr;
+				const auto InstancedStruct = ContainerPtr
+					? Entry.NestedStructProp->ContainerPtrToValuePtr<FInstancedStruct>(ContainerPtr)
+					: nullptr;
 
-				// Check if it's a InstancedStruct
-             	if(SProp->Struct->IsChildOf(FInstancedStruct::StaticStruct()))
-             	{
-             		// If it is, we need to get the actual struct from the property
-             		const FInstancedStruct* InstancedStruct = ContainerPtr ? SProp->ContainerPtrToValuePtr<FInstancedStruct>(ContainerPtr) : nullptr;
+				if (InstancedStruct)
+				{
+					if (!InstancedStruct->IsValid())
+					{
+						continue;
+					}
 
-             		if(InstancedStruct)
-             		{
-             			if(!InstancedStruct->IsValid())
-             			{
-             				// If it's not valid, ignore it
-			 				continue;
-             			}
-
-             			StructDefinition = InstancedStruct->GetScriptStruct();
-			 			StructPtr = (void*)InstancedStruct->GetMemory();
-             		}
-             	}
-                else
-                {
-                	StructDefinition = SProp->Struct;
-                	StructPtr = ContainerPtr ? SProp->ContainerPtrToValuePtr<void>(ContainerPtr) : nullptr;
-                }
-
-				// Everything underneath a custom struct is recorded with a nested prefix
-				const uint32 NewPrefixID = Visitor.GetNestedPrefix(SProp, PrefixID);
-				// Should never have no prefix, if none abort
-				if (NewPrefixID == SPUDDATA_PREFIXID_NONE)
-					continue;
-
-				const int NewDepth = Depth + 1;
-		
-				Visitor.StartNestedStruct(RootObject, SProp, NewPrefixID, NewDepth);
-				if (!VisitPersistentProperties(RootObject, StructDefinition, NewPrefixID, StructPtr, true, NewDepth, Visitor))
-					return false;				
-				Visitor.EndNestedStruct(RootObject, SProp, NewPrefixID, NewDepth);
+					StructDefinition = InstancedStruct->GetScriptStruct();
+					StructPtr = const_cast<uint8*>(InstancedStruct->GetMemory());
+				}
 			}
-		}
+			else
+			{
+				StructDefinition = Entry.NestedStructProp->Struct;
+				StructPtr = ContainerPtr ? Entry.NestedStructProp->ContainerPtrToValuePtr<void>(ContainerPtr) : nullptr;
+			}
 
-		// We no longer cascade into UObjects here, since they are separate types
-		// They will be cascaded into by visitors because whether / how you cascade depends on the runtime instance type (or null)
+			const uint32 NewPrefixID = Visitor.GetNestedPrefix(Entry.NestedStructProp, PrefixID);
+			if (NewPrefixID == SPUDDATA_PREFIXID_NONE)
+				continue;
+
+			const int NewDepth = Depth + 1;
+
+			Visitor.StartNestedStruct(RootObject, Entry.NestedStructProp, NewPrefixID, NewDepth);
+			if (!VisitPersistentProperties(RootObject, StructDefinition, NewPrefixID, StructPtr, true, NewDepth, Visitor))
+				return false;
+			Visitor.EndNestedStruct(RootObject, Entry.NestedStructProp, NewPrefixID, NewDepth);
+		}
 	}
 
 	return true;
@@ -1405,5 +1435,3 @@ FString SpudPropertyUtil::GetLogPrefix(const FProperty* Property, int Depth)
 
 	return FString::Printf(TEXT(" |%s %s"), *Prefix, *Property->GetNameCPP());
 }
-
-

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -487,17 +487,17 @@ void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserInd
 				{
 					FMemoryWriter Archive(*OutSaveData, true);
 					RawState->SaveToArchive(Archive);
-		Archive.Close();
-		if (Archive.IsError() || Archive.IsCriticalError())
-		{
-			UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
-						CompleteOnGameThread(false);
-						return;
-					}
-		}
+					Archive.Close();
+					if (Archive.IsError() || Archive.IsCriticalError())
+					{
+						UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
+							CompleteOnGameThread(false);
+							return;
+						}
+				}
 
 				if (OutSaveData->Num() == 0 || SlotName.IsEmpty())
-		{
+				{
 					UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
 					CompleteOnGameThread(false);
 					return;

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -17,8 +17,8 @@
 DEFINE_LOG_CATEGORY(LogSpudSubsystem)
 
 
-#define SPUD_QUICKSAVE_SLOTNAME "__QuickSave__"
-#define SPUD_AUTOSAVE_SLOTNAME "__AutoSave__"
+#define SPUD_QUICKSAVE_SLOTNAME TEXT("__QuickSave__")
+#define SPUD_AUTOSAVE_SLOTNAME TEXT("__AutoSave__")
 
 
 void USpudSubsystem::Initialize(FSubsystemCollectionBase& Collection)
@@ -147,38 +147,148 @@ void USpudSubsystem::EndGame()
 
 void USpudSubsystem::AutoSaveGame(FText Title, bool bTakeScreenshot, const USpudCustomSaveInfo* ExtraInfo, const int32 UserIndex, bool bAsync)
 {
-	SaveGame(SPUD_AUTOSAVE_SLOTNAME,
-		Title.IsEmpty() ? NSLOCTEXT("Spud", "AutoSaveTitle", "Autosave") : Title,
-		bTakeScreenshot,
-		ExtraInfo,
-		UserIndex,
-		bAsync);
+	FString SlotName;
+	FText DefaultTitle;
+
+	if (MaxAutoSaves > 0)
+	{
+		const auto NextNumber = FMath::Max(1, GetHighestSlotNumber(SPUD_AUTOSAVE_SLOTNAME, UserIndex) + 1);
+		SlotName = MakeNumberedSlotName(SPUD_AUTOSAVE_SLOTNAME, NextNumber);
+		DefaultTitle = FText::Format(NSLOCTEXT("Spud", "AutoSaveTitleNumbered", "Autosave {0}"), NextNumber);
+		CleanupOldNumberedSaves(SPUD_AUTOSAVE_SLOTNAME, MaxAutoSaves, NextNumber, UserIndex);
+	}
+	else
+	{
+		SlotName = SPUD_AUTOSAVE_SLOTNAME;
+		DefaultTitle = NSLOCTEXT("Spud", "AutoSaveTitle", "Autosave");
+	}
+
+	SaveGame(SlotName, Title.IsEmpty() ? DefaultTitle : Title, bTakeScreenshot, ExtraInfo, UserIndex, bAsync);
 }
 
 void USpudSubsystem::QuickSaveGame(FText Title, bool bTakeScreenshot, const USpudCustomSaveInfo* ExtraInfo, const int32 UserIndex, bool bAsync)
 {
-	SaveGame(SPUD_QUICKSAVE_SLOTNAME,
-		Title.IsEmpty() ? NSLOCTEXT("Spud", "QuickSaveTitle", "Quick Save") : Title,
-		bTakeScreenshot,
-		ExtraInfo,
-		UserIndex,
-		bAsync);
+	FString SlotName;
+	FText DefaultTitle;
+
+	if (MaxQuickSaves > 0)
+	{
+		const auto NextNumber = FMath::Max(1, GetHighestSlotNumber(SPUD_QUICKSAVE_SLOTNAME,UserIndex) + 1);
+		SlotName = MakeNumberedSlotName(SPUD_QUICKSAVE_SLOTNAME,NextNumber);
+		DefaultTitle = FText::Format(NSLOCTEXT("Spud", "QuickSaveTitleNumbered", "Quick Save {0}"), NextNumber);
+		CleanupOldNumberedSaves(SPUD_QUICKSAVE_SLOTNAME, MaxQuickSaves,NextNumber, UserIndex);
+	}
+	else
+	{
+		SlotName = SPUD_QUICKSAVE_SLOTNAME;
+		DefaultTitle = NSLOCTEXT("Spud", "QuickSaveTitle", "Quick Save");
+	}
+
+	SaveGame(SlotName, Title.IsEmpty() ? DefaultTitle : Title, bTakeScreenshot, ExtraInfo, UserIndex, bAsync);
 }
 
 void USpudSubsystem::QuickLoadGame(const FString& TravelOptions, const int32 UserIndex)
 {
-	LoadGame(SPUD_QUICKSAVE_SLOTNAME, TravelOptions, UserIndex);
+	FString SlotName;
+	if (MaxQuickSaves > 0)
+	{
+		const auto LatestNumber = GetHighestSlotNumber(SPUD_QUICKSAVE_SLOTNAME,UserIndex);
+		if (LatestNumber > 0)
+		{
+			SlotName = MakeNumberedSlotName(SPUD_QUICKSAVE_SLOTNAME,LatestNumber);
+		}
+		else if (LatestNumber == 0)
+		{
+			SlotName = SPUD_QUICKSAVE_SLOTNAME;
+		}
+		else
+		{
+			return;
+		}
+	}
+	else
+	{
+		SlotName = SPUD_QUICKSAVE_SLOTNAME;
+	}
+
+	LoadGame(SlotName, TravelOptions, UserIndex);
 }
 
 
 bool USpudSubsystem::IsQuickSave(const FString& SlotName)
 {
-	return SlotName == SPUD_QUICKSAVE_SLOTNAME;
+	int32 Unused;
+	return ParseNumberedSlotName(SlotName, SPUD_QUICKSAVE_SLOTNAME, Unused);
 }
 
 bool USpudSubsystem::IsAutoSave(const FString& SlotName)
 {
-	return SlotName == SPUD_AUTOSAVE_SLOTNAME;
+	int32 Unused;
+	return ParseNumberedSlotName(SlotName, SPUD_AUTOSAVE_SLOTNAME, Unused);
+}
+
+bool USpudSubsystem::ParseNumberedSlotName(const FString& SlotName, const TCHAR* BaseSlotName, int32& OutNumber)
+{
+	if (SlotName == BaseSlotName)
+	{
+		OutNumber = 0;
+		return true;
+	}
+
+	const FString Base(BaseSlotName);
+	const auto Prefix = Base.LeftChop(2) + TEXT("_");
+	if (SlotName.StartsWith(Prefix) && SlotName.EndsWith(TEXT("__")) && SlotName.Len() > Prefix.Len() + 2)
+	{
+		const auto NumberStr = SlotName.Mid(Prefix.Len(), SlotName.Len() - Prefix.Len() - 2);
+		if (NumberStr.IsNumeric())
+		{
+			OutNumber = FCString::Atoi(*NumberStr);
+			return OutNumber > 0;
+		}
+	}
+
+	return false;
+}
+
+FString USpudSubsystem::MakeNumberedSlotName(const TCHAR* BaseSlotName, int32 Number)
+{
+	const FString Base(BaseSlotName);
+	return Base.LeftChop(2) + FString::Printf(TEXT("_%d__"), Number);
+}
+
+int32 USpudSubsystem::GetHighestSlotNumber(const TCHAR* BaseSlotName, const int32 UserIndex) const
+{
+	TArray<FString> SaveFiles;
+	ListSaveGameFiles(SaveFiles, UserIndex);
+
+	auto HighestNumber = -1;
+	for (const auto& File : SaveFiles)
+	{
+		const auto SlotName = FPaths::GetBaseFilename(File);
+		int32 Number;
+		if (ParseNumberedSlotName(SlotName, BaseSlotName, Number) && Number > HighestNumber)
+		{
+			HighestNumber = Number;
+		}
+	}
+	return HighestNumber;
+}
+
+void USpudSubsystem::CleanupOldNumberedSaves(const TCHAR* BaseSlotName, int32 MaxToKeep, int32 LatestNumber, const int32 UserIndex)
+{
+	TArray<FString> SaveFiles;
+	ListSaveGameFiles(SaveFiles, UserIndex);
+
+	const auto OldestToKeep = LatestNumber - MaxToKeep + 1;
+	for (const auto& File : SaveFiles)
+	{
+		const auto SlotName = FPaths::GetBaseFilename(File);
+		int32 Number;
+		if (ParseNumberedSlotName(SlotName, BaseSlotName, Number) && Number < OldestToKeep)
+		{
+			DeleteSave(SlotName, UserIndex);
+		}
+	}
 }
 
 void USpudSubsystem::NotifyLevelLoadedExternally(FName LevelName)
@@ -1356,11 +1466,42 @@ USpudSaveGameInfo* USpudSubsystem::GetLatestSaveGame(const int32 UserIndex)
 
 USpudSaveGameInfo* USpudSubsystem::GetQuickSaveGame(const int32 UserIndex)
 {
+	if (MaxQuickSaves > 0)
+	{
+		const auto LatestNumber = GetHighestSlotNumber(SPUD_QUICKSAVE_SLOTNAME,UserIndex);
+		if (LatestNumber > 0)
+		{
+			return GetSaveGameInfo(MakeNumberedSlotName(SPUD_QUICKSAVE_SLOTNAME,LatestNumber), UserIndex);
+		}
+		
+		if (LatestNumber == 0)
+		{
+			return GetSaveGameInfo(SPUD_QUICKSAVE_SLOTNAME, UserIndex);
+		}
+		
+		return nullptr;
+	}
+	
 	return GetSaveGameInfo(SPUD_QUICKSAVE_SLOTNAME, UserIndex);
 }
 
 USpudSaveGameInfo* USpudSubsystem::GetAutoSaveGame(const int32 UserIndex)
 {
+	if (MaxAutoSaves > 0)
+	{
+		const auto LatestNumber = GetHighestSlotNumber(SPUD_AUTOSAVE_SLOTNAME, UserIndex);
+		if (LatestNumber > 0)
+		{
+			return GetSaveGameInfo(MakeNumberedSlotName(SPUD_AUTOSAVE_SLOTNAME, LatestNumber), UserIndex);
+		}
+		if (LatestNumber == 0)
+		{
+			return GetSaveGameInfo(SPUD_AUTOSAVE_SLOTNAME, UserIndex);
+		}
+		
+		return nullptr;
+	}
+	
 	return GetSaveGameInfo(SPUD_AUTOSAVE_SLOTNAME, UserIndex);
 }
 

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -11,6 +11,8 @@
 
 #include "SaveGameSystem.h"
 #include "PlatformFeatures.h"
+#include "Engine/GameViewportClient.h"
+#include "Slate/SceneViewport.h"
 
 DEFINE_LOG_CATEGORY(LogSpudSubsystem)
 
@@ -331,23 +333,41 @@ void USpudSubsystem::SaveGame(const FString& SlotName, const FText& Title, bool 
 
 	if (bTakeScreenshot)
 	{
-		UE_LOG(LogSpudSubsystem, Verbose, TEXT("Queueing screenshot for save %s"), *SlotName);
-
-		// Memory-based screenshot request
 		SlotNameInProgress = SlotName;
 		TitleInProgress = Title;
 		ExtraInfoInProgress = ExtraInfo;
-		UGameViewportClient* ViewportClient = UGameplayStatics::GetPlayerController(GetWorld(), UserIndex)->GetLocalPlayer()->ViewportClient;
-		OnScreenshotCapturedHandle = ViewportClient->OnScreenshotCaptured().AddUObject(this, &USpudSubsystem::OnScreenshotCaptured, UserIndex);
-		OnScreenshotRequestProcessedHandle = FScreenshotRequest::OnScreenshotRequestProcessed().AddUObject(this, &USpudSubsystem::OnScreenshotRequestProcessed, UserIndex);
-		FScreenshotRequest::RequestScreenshot(false);
-		ScreenshotFileName = FScreenshotRequest::GetFilename();
-		// OnScreenShotCaptured will finish
-		// EXCEPT that if a Widget BP is open in the editor, this request will disappear into nowhere!! (4.26.1)
-		// So we need a failsafe
-		// Wait for 1 second. Can't use FTimerManager because there's no option for those to tick while game paused (which is common in saves!)
-		float& ScreenShotTimeout = ScreenshotTimeouts.FindOrAdd(UserIndex);
-		ScreenShotTimeout = 1.0f;
+
+		static const auto CVarHDR = IConsoleManager::Get().FindTConsoleVariableDataInt(TEXT("r.HDR.EnableHDROutput"));
+		const bool bHDROutput = CVarHDR && CVarHDR->GetValueOnGameThread() != 0;
+
+		if (!bHDROutput)
+		{
+			if (const auto Viewport = GEngine->GameViewport ? GEngine->GameViewport->GetGameViewport() : nullptr)
+			{
+				TArray<FColor> Pixels;
+				if (const auto Size = Viewport->GetSizeXY(); Size.X > 0 && Size.Y > 0 && Viewport->ReadPixels(Pixels))
+				{
+					OnScreenshotCaptured(Size.X, Size.Y, Pixels, UserIndex);
+					return;
+				}
+			}
+		}
+		else if (const auto PC = UGameplayStatics::GetPlayerController(GetWorld(), UserIndex))
+		{
+			if (const auto LP = PC->GetLocalPlayer(); LP && LP->ViewportClient)
+			{
+				OnScreenshotCapturedHandle = LP->ViewportClient->OnScreenshotCaptured().AddUObject(this, &USpudSubsystem::OnScreenshotCaptured, UserIndex);
+				OnScreenshotRequestProcessedHandle = FScreenshotRequest::OnScreenshotRequestProcessed().AddUObject(this, &USpudSubsystem::OnScreenshotRequestProcessed, UserIndex);
+				FScreenshotRequest::RequestScreenshot(false);
+				ScreenshotFileName = FScreenshotRequest::GetFilename();
+				float& ScreenShotTimeout = ScreenshotTimeouts.FindOrAdd(UserIndex);
+				ScreenShotTimeout = 1.0f;
+				return;
+			}
+		}
+
+		UE_LOG(LogSpudSubsystem, Warning, TEXT("Failed to read viewport pixels for save screenshot, saving without thumbnail"));
+		FinishSaveGame(SlotName, UserIndex, Title, ExtraInfo, nullptr);
 	}
 	else
 	{
@@ -357,15 +377,10 @@ void USpudSubsystem::SaveGame(const FString& SlotName, const FText& Title, bool 
 
 void USpudSubsystem::ScreenshotTimedOut(const int32 UserIndex)
 {
-	// We failed to get a screenshot back in time
-	// This is mostly likely down to a weird fecking issue in PIE where if ANY Widget Blueprint is open while a screenshot
-	// is requested, that request is never fulfilled
-
-	UE_LOG(LogSpudSubsystem, Error, TEXT("Request for save screenshot timed out. This is most likely a UE4 bug: "
+	UE_LOG(LogSpudSubsystem, Error, TEXT("Request for save screenshot timed out. This is most likely a UE bug: "
 		"Widget Blueprints being open in the editor during PIE seems to break screenshots. Completing save game without a screenshot."))
 
-	float& ScreenShotTimeout = ScreenshotTimeouts.FindOrAdd(UserIndex);
-	ScreenShotTimeout = 0.0f;
+	ResetScreenshotState(UserIndex);
 	FinishSaveGame(SlotNameInProgress, UserIndex, TitleInProgress, ExtraInfoInProgress, nullptr);
 }
 
@@ -373,19 +388,32 @@ void USpudSubsystem::OnScreenshotCaptured(int32 Width, int32 Height, const TArra
 {
 	ResetScreenshotState(UserIndex);
 
-	// Downscale the screenshot, pass to finish
-	TArray<FColor> RawDataCroppedResized;
-	FImageUtils::CropAndScaleImage(Width, Height, ScreenshotWidth, ScreenshotHeight, Colours, RawDataCroppedResized);
+	const int32 TargetWidth = ScreenshotWidth;
+	const int32 TargetHeight = ScreenshotHeight;
+	TWeakObjectPtr WeakThis(this);
 
-	// Convert down to PNG
-	TArray<uint8> PngData;
+	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
+		[WeakThis, RawPixels = Colours, Width, Height, TargetWidth, TargetHeight, UserIndex]() mutable
+		{
+			TArray<FColor> CroppedResized;
+			FImageUtils::CropAndScaleImage(Width, Height, TargetWidth, TargetHeight, RawPixels, CroppedResized);
+			RawPixels.Empty();
+
+			auto PngData = MakeShared<TArray<uint8>>();
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-	FImageUtils::ThumbnailCompressImageArray(ScreenshotWidth, ScreenshotHeight, RawDataCroppedResized, PngData);
+			FImageUtils::ThumbnailCompressImageArray(TargetWidth, TargetHeight, CroppedResized, *PngData);
 #else
-	FImageUtils::CompressImageArray(ScreenshotWidth, ScreenshotHeight, RawDataCroppedResized, PngData);
+			FImageUtils::CompressImageArray(TargetWidth, TargetHeight, CroppedResized, *PngData);
 #endif
-	
-	FinishSaveGame(SlotNameInProgress, UserIndex, TitleInProgress, ExtraInfoInProgress, &PngData);
+
+			AsyncTask(ENamedThreads::GameThread, [WeakThis, PngData, UserIndex]()
+			{
+				if (auto* S = WeakThis.Get())
+				{
+					S->FinishSaveGame(S->SlotNameInProgress, UserIndex, S->TitleInProgress, S->ExtraInfoInProgress, &*PngData);
+				}
+			});
+		});
 }
 
 void USpudSubsystem::ResetScreenshotState(const int32 UserIndex)
@@ -393,28 +421,49 @@ void USpudSubsystem::ResetScreenshotState(const int32 UserIndex)
 	float& ScreenShotTimeout = ScreenshotTimeouts.FindOrAdd(UserIndex);
 	ScreenShotTimeout = 0.0f;
 
-	const auto ViewportClient = UGameplayStatics::GetPlayerController(GetWorld(), UserIndex)->GetLocalPlayer()->ViewportClient;
-	ViewportClient->OnScreenshotCaptured().Remove(OnScreenshotCapturedHandle);
+	if (const auto PC = UGameplayStatics::GetPlayerController(GetWorld(), UserIndex))
+	{
+		if (const auto LP = PC->GetLocalPlayer())
+		{
+			if (const auto VC = LP->ViewportClient)
+			{
+				VC->OnScreenshotCaptured().Remove(OnScreenshotCapturedHandle);
+			}
+		}
+	}
 
 	FScreenshotRequest::OnScreenshotRequestProcessed().Remove(OnScreenshotRequestProcessedHandle);
-
 	OnScreenshotCapturedHandle.Reset();
 	OnScreenshotRequestProcessedHandle.Reset();
 }
 
 void USpudSubsystem::OnScreenshotRequestProcessed(const int32 UserIndex)
 {
-	// handles HDR screenshots
+	ResetScreenshotState(UserIndex);
 
-	FImage Image;
-	FImageUtils::LoadImage(*ScreenshotFileName, Image);
+	const FString FileName = ScreenshotFileName;
+	TWeakObjectPtr WeakThis(this);
 
-	// clean up temp screenshot
-	IFileManager::Get().Delete(*ScreenshotFileName);
+	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
+		[WeakThis, FileName, UserIndex]()
+		{
+			FImage Image;
+			FImageUtils::LoadImage(*FileName, Image);
+			IFileManager::Get().Delete(*FileName);
+			Image.ChangeFormat(ERawImageFormat::BGRA8, Image.GammaSpace);
 
-	Image.ChangeFormat(ERawImageFormat::BGRA8, Image.GammaSpace);
+			const auto W = Image.GetWidth();
+			const auto H = Image.GetHeight();
+			TArray<FColor> Pixels(Image.AsBGRA8());
 
-	OnScreenshotCaptured(Image.GetWidth(), Image.GetHeight(), TArray<FColor>(Image.AsBGRA8()), UserIndex);
+			AsyncTask(ENamedThreads::GameThread, [WeakThis, Pixels = MoveTemp(Pixels), W, H, UserIndex]()
+			{
+				if (auto* S = WeakThis.Get())
+				{
+					S->OnScreenshotCaptured(W, H, Pixels, UserIndex);
+				}
+			});
+		});
 }
 
 void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserIndex, const FText& Title, const USpudCustomSaveInfo* ExtraInfo, TArray<uint8>* ScreenshotData)

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -126,22 +126,24 @@ void USpudSubsystem::EndGame()
 	IsRestoringState = false;
 }
 
-void USpudSubsystem::AutoSaveGame(FText Title, bool bTakeScreenshot, const USpudCustomSaveInfo* ExtraInfo, const int32 UserIndex)
+void USpudSubsystem::AutoSaveGame(FText Title, bool bTakeScreenshot, const USpudCustomSaveInfo* ExtraInfo, const int32 UserIndex, bool bAsync)
 {
 	SaveGame(SPUD_AUTOSAVE_SLOTNAME,
 		Title.IsEmpty() ? NSLOCTEXT("Spud", "AutoSaveTitle", "Autosave") : Title,
 		bTakeScreenshot,
 		ExtraInfo,
-		UserIndex);
+		UserIndex,
+		bAsync);
 }
 
-void USpudSubsystem::QuickSaveGame(FText Title, bool bTakeScreenshot, const USpudCustomSaveInfo* ExtraInfo, const int32 UserIndex)
+void USpudSubsystem::QuickSaveGame(FText Title, bool bTakeScreenshot, const USpudCustomSaveInfo* ExtraInfo, const int32 UserIndex, bool bAsync)
 {
 	SaveGame(SPUD_QUICKSAVE_SLOTNAME,
 		Title.IsEmpty() ? NSLOCTEXT("Spud", "QuickSaveTitle", "Quick Save") : Title,
 		bTakeScreenshot,
 		ExtraInfo,
-		UserIndex);
+		UserIndex,
+		bAsync);
 }
 
 void USpudSubsystem::QuickLoadGame(const FString& TravelOptions, const int32 UserIndex)

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -81,6 +81,15 @@ void USpudSubsystem::NewGame(bool bCheckServerOnly, bool bAfterLevelLoad)
 	if (bCheckServerOnly && !ServerCheck(true))
 		return;
 		
+	if (IsSavingGame())
+	{
+		UE_LOG(LogSpudSubsystem, Log, TEXT("NewGame deferred until async save completes"));
+		bPendingEndGame = false;
+		PendingNewGameArgs.Emplace(bCheckServerOnly, bAfterLevelLoad);
+		return;
+	}
+	PendingNewGameArgs.Reset();
+
 	EndGame();
 	
 	// EndGame will have unsubscribed from all current levels
@@ -114,6 +123,15 @@ bool USpudSubsystem::ServerCheck(bool LogWarning) const
 
 void USpudSubsystem::EndGame()
 {
+	if (CurrentState == ESpudSystemState::SavingGameAsync)
+	{
+		UE_LOG(LogSpudSubsystem, Log, TEXT("EndGame deferred until async save completes"));
+		PendingNewGameArgs.Reset();
+		bPendingEndGame = true;
+		return;
+	}
+	bPendingEndGame = false;
+
 	if (ActiveState)
 		ActiveState->ResetState();
 	
@@ -410,12 +428,12 @@ void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserInd
 
 	State->StoreWorldGlobals(World);
 	
-	for (auto Ptr : GlobalObjects)
+	for (const auto& Ptr : GlobalObjects)
 	{
 		if (Ptr.IsValid())
 			State->StoreGlobalObject(Ptr.Get());
 	}
-	for (auto Pair : NamedGlobalObjects)
+	for (const auto& Pair : NamedGlobalObjects)
 	{
 		if (Pair.Value.IsValid())
 			State->StoreGlobalObject(Pair.Value.Get(), Pair.Key);
@@ -430,25 +448,65 @@ void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserInd
 	if (ScreenshotData)
 		State->SetScreenshot(*ScreenshotData);
 
-	if (ISaveGameSystem* SaveSystem = IPlatformFeaturesModule::Get().GetSaveGameSystem())
+	ISaveGameSystem* SaveSystem = IPlatformFeaturesModule::Get().GetSaveGameSystem();
+	if (!SaveSystem)
 	{
-		TSharedRef<TArray<uint8>> OutSaveData(new TArray<uint8>());
-		auto Archive = FMemoryWriter(*OutSaveData, true);
-		State->SaveToArchive(Archive);
-		Archive.Close();
+		SaveComplete(SlotName, UserIndex, false);
+		return;
+	}
 
+	if (CurrentState == ESpudSystemState::SavingGameAsync)
+	{
+		// StoreWorld has finished capturing all actor data into plain struct buffers.
+		// SaveToArchive only reads those buffers (no UObject derefs) so it can safely
+		// run on a background thread. EndGame() is guarded against SavingGameAsync,
+		// so ActiveState (UPROPERTY) remains alive for the duration of the task.
+		TWeakObjectPtr WeakState(State);
+		TWeakObjectPtr WeakThis(this);
+		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
+			[WeakThis, WeakState, SaveSystem, SlotName, UserIndex]()
+			{
+				auto CompleteOnGameThread = [WeakThis, SlotName, UserIndex](bool bSuccess)
+				{
+					AsyncTask(ENamedThreads::GameThread, [WeakThis, SlotName, UserIndex, bSuccess]()
+	{
+						if (USpudSubsystem* S = WeakThis.Get())
+							S->SaveComplete(SlotName, UserIndex, bSuccess);
+					});
+				};
+
+				const auto RawState = WeakState.Get();
+				if (!RawState)
+				{
+					UE_LOG(LogSpudSubsystem, Error, TEXT("Save state was destroyed before async serialization could start for slot %s"), *SlotName);
+					CompleteOnGameThread(false);
+					return;
+				}
+
+				TSharedRef<TArray<uint8>> OutSaveData = MakeShared<TArray<uint8>>();
+				{
+					FMemoryWriter Archive(*OutSaveData, true);
+					RawState->SaveToArchive(Archive);
+		Archive.Close();
 		if (Archive.IsError() || Archive.IsCriticalError())
 		{
 			UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
-			SaveComplete(SlotName, UserIndex, false);
+						CompleteOnGameThread(false);
+						return;
+					}
 		}
-		else
+
+				if (OutSaveData->Num() == 0 || SlotName.IsEmpty())
 		{
-			if ((OutSaveData->Num() > 0) && (SlotName.Len() > 0))
-			{
-				if (CurrentState == ESpudSystemState::SavingGameAsync)
+					UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
+					CompleteOnGameThread(false);
+					return;
+				}
+
+				// Dispatch disk write from the game thread for platform safety - console
+				// save systems may not support calls from arbitrary background threads.
+				AsyncTask(ENamedThreads::GameThread, [WeakThis, SaveSystem, SlotName, UserIndex, OutSaveData]()
 				{
-					TWeakObjectPtr<USpudSubsystem> WeakThis(this);
 					SaveSystem->SaveGameAsync(false, *SlotName, FPlatformMisc::GetPlatformUserForUserIndex(UserIndex), OutSaveData,
 						[WeakThis, UserIndex, SlotName](const FString&, FPlatformUserId, bool bSuccess)
 						{
@@ -468,11 +526,24 @@ void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserInd
 								S->SaveComplete(SlotName, UserIndex, bSuccess);
 							}
 						});
+				});
+			});
 				}
 				else
 				{
-					bool SaveOK;
+		TSharedRef<TArray<uint8>> OutSaveData(new TArray<uint8>());
+		auto Archive = FMemoryWriter(*OutSaveData, true);
+		State->SaveToArchive(Archive);
+		Archive.Close();
 
+		if (Archive.IsError() || Archive.IsCriticalError())
+		{
+			UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
+			SaveComplete(SlotName, UserIndex, false);
+		}
+		else if (OutSaveData->Num() > 0 && SlotName.Len() > 0)
+		{
+					bool SaveOK;
 					if (!SaveSystem->SaveGame(false, *SlotName, UserIndex, *OutSaveData))
 					{
 						UE_LOG(LogSpudSubsystem, Error, TEXT("Error while saving game to %s"), *SlotName);
@@ -483,20 +554,13 @@ void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserInd
 						UE_LOG(LogSpudSubsystem, Log, TEXT("Save to slot %s: Success"), *SlotName);
 						SaveOK = true;
 					}
-
 					SaveComplete(SlotName, UserIndex, SaveOK);
 				}
-			}
 			else
 			{
 				UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
 				SaveComplete(SlotName, UserIndex, false);
 			}
-		}
-	}
-	else
-	{
-		SaveComplete(SlotName, UserIndex, false);
 	}
 }
 
@@ -508,6 +572,18 @@ void USpudSubsystem::SaveComplete(const FString& SlotName, const int32 UserIndex
 	SlotNameInProgress = "";
 	TitleInProgress = FText();
 	ExtraInfoInProgress = nullptr;
+
+	if (PendingNewGameArgs.IsSet())
+	{
+		const auto [bCheckServerOnly, bAfterLevelLoad] = PendingNewGameArgs.GetValue();
+		PendingNewGameArgs.Reset();
+		NewGame(bCheckServerOnly, bAfterLevelLoad);
+	}
+	else if (bPendingEndGame)
+	{
+		bPendingEndGame = false;
+		EndGame();
+	}
 }
 
 void USpudSubsystem::HandleLevelLoaded(FName LevelName)
@@ -520,7 +596,7 @@ void USpudSubsystem::HandleLevelLoaded(FName LevelName)
 	// that way the loading occurs in this thread, less latency
 	GetActiveState()->PreLoadLevelData(LevelName.ToString());
 
-	TWeakObjectPtr<USpudSubsystem> WeakThis(this);
+	TWeakObjectPtr WeakThis(this);
 	AsyncTask(ENamedThreads::GameThread, [WeakThis, LevelName]()
 	{
 		USpudSubsystem* Self = WeakThis.Get();
@@ -696,12 +772,12 @@ void USpudSubsystem::LoadGame(const FString& SlotName, const FString& TravelOpti
 	
 	// Just do the reverse of what we did
 	// Global objects first before map, these should be only objects which survive map load
-	for (auto Ptr : GlobalObjects)
+	for (const auto& Ptr : GlobalObjects)
 	{
 		if (Ptr.IsValid())
 			State->RestoreGlobalObject(Ptr.Get());
 	}
-	for (auto Pair : NamedGlobalObjects)
+	for (const auto& Pair : NamedGlobalObjects)
 	{
 		if (Pair.Value.IsValid())
 			State->RestoreGlobalObject(Pair.Value.Get(), Pair.Key);
@@ -747,7 +823,7 @@ bool USpudSubsystem::DeleteSave(const FString& SlotName, const int32 UserIndex)
 
 void USpudSubsystem::AddPersistentGlobalObject(UObject* Obj)
 {
-	GlobalObjects.AddUnique(TWeakObjectPtr<UObject>(Obj));	
+	GlobalObjects.AddUnique(TWeakObjectPtr(Obj));
 }
 
 void USpudSubsystem::AddPersistentGlobalObjectWithName(UObject* Obj, const FString& Name)
@@ -757,7 +833,7 @@ void USpudSubsystem::AddPersistentGlobalObjectWithName(UObject* Obj, const FStri
 
 void USpudSubsystem::RemovePersistentGlobalObject(UObject* Obj)
 {
-	GlobalObjects.Remove(TWeakObjectPtr<UObject>(Obj));
+	GlobalObjects.Remove(TWeakObjectPtr(Obj));
 	
 	for (auto It = NamedGlobalObjects.CreateIterator(); It; ++It)
 	{
@@ -997,6 +1073,8 @@ void USpudSubsystem::ForceReset()
 {
 	CurrentState = ESpudSystemState::RunningIdle;
 	IsRestoringState = false;
+	bPendingEndGame = false;
+	PendingNewGameArgs.Reset();
 }
 
 void USpudSubsystem::SetUserDataModelVersion(int32 Version)
@@ -1034,9 +1112,10 @@ bool USpudSubsystem::ShouldStoreLevel(const ULevel* Level)
 	if (!Level)
 		return false;
 	
-	for (auto Pattern : ExcludeLevelNamePatterns)
+	const auto LevelName = USpudState::GetLevelName(Level);
+	for (const auto& Pattern : ExcludeLevelNamePatterns)
 	{
-		if (USpudState::GetLevelName(Level).MatchesWildcard(Pattern))
+		if (LevelName.MatchesWildcard(Pattern))
 		{
 			return false;
 		}
@@ -1538,7 +1617,7 @@ void USpudSubsystem::Tick(float DeltaTime)
 		// only for authority.
 		if (world && world->GetAuthGameMode())
 		{
-			TSet<ULevelStreaming*> streamingLevels(world->GetStreamingLevels());
+			const auto& streamingLevels = world->GetStreamingLevels();
 
 			// Find newly added levels.
 			for (const auto level : streamingLevels)

--- a/Source/SPUD/Private/SpudSubsystem.cpp
+++ b/Source/SPUD/Private/SpudSubsystem.cpp
@@ -1,8 +1,8 @@
 #include "SpudSubsystem.h"
 #include "SpudState.h"
 #include "Engine/LevelStreaming.h"
-#include "Engine/LocalPlayer.h"
 #include "Kismet/GameplayStatics.h"
+#include "GameFramework/GameUserSettings.h"
 #include "ImageUtils.h"
 #include "TimerManager.h"
 #include "HAL/FileManager.h"
@@ -337,32 +337,44 @@ void USpudSubsystem::SaveGame(const FString& SlotName, const FText& Title, bool 
 		TitleInProgress = Title;
 		ExtraInfoInProgress = ExtraInfo;
 
-		static const auto CVarHDR = IConsoleManager::Get().FindTConsoleVariableDataInt(TEXT("r.HDR.EnableHDROutput"));
-		const bool bHDROutput = CVarHDR && CVarHDR->GetValueOnGameThread() != 0;
-
-		if (!bHDROutput)
+		if (const auto Viewport = GEngine->GameViewport ? GEngine->GameViewport->GetGameViewport() : nullptr)
 		{
-			if (const auto Viewport = GEngine->GameViewport ? GEngine->GameViewport->GetGameViewport() : nullptr)
+			if (const auto Size = Viewport->GetSizeXY(); Size.X > 0 && Size.Y > 0)
 			{
-				TArray<FColor> Pixels;
-				if (const auto Size = Viewport->GetSizeXY(); Size.X > 0 && Size.Y > 0 && Viewport->ReadPixels(Pixels))
+				if (GEngine->GetGameUserSettings()->IsHDREnabled())
 				{
-					OnScreenshotCaptured(Size.X, Size.Y, Pixels, UserIndex);
+					if (TArray<FLinearColor> HDRPixels; Viewport->ReadLinearColorPixels(HDRPixels))
+					{
+						TWeakObjectPtr WeakThis(this);
+						AsyncTask(ENamedThreads::AnyBackgroundHiPriTask,
+							[WeakThis, HDRPixels = MoveTemp(HDRPixels), W = Size.X, H = Size.Y, UserIndex]() mutable
+							{
+								TArray<FColor> Pixels;
+								Pixels.SetNumUninitialized(HDRPixels.Num());
+								for (auto i = 0; i < HDRPixels.Num(); ++i)
+								{
+									Pixels[i] = HDRPixels[i].ToFColor(true);
+								}
+								HDRPixels.Empty();
+
+								AsyncTask(ENamedThreads::GameThread, [WeakThis, Pixels = MoveTemp(Pixels), W, H, UserIndex]() mutable
+								{
+									if (const auto S = WeakThis.Get())
+									{
+										S->OnScreenshotCaptured(W, H, MoveTemp(Pixels), UserIndex);
+									}
+								});
+							}
+						);
+							
+						return;
+					}
+				}
+				else if (TArray<FColor> Pixels; Viewport->ReadPixels(Pixels))
+				{
+					OnScreenshotCaptured(Size.X, Size.Y, MoveTemp(Pixels), UserIndex);
 					return;
 				}
-			}
-		}
-		else if (const auto PC = UGameplayStatics::GetPlayerController(GetWorld(), UserIndex))
-		{
-			if (const auto LP = PC->GetLocalPlayer(); LP && LP->ViewportClient)
-			{
-				OnScreenshotCapturedHandle = LP->ViewportClient->OnScreenshotCaptured().AddUObject(this, &USpudSubsystem::OnScreenshotCaptured, UserIndex);
-				OnScreenshotRequestProcessedHandle = FScreenshotRequest::OnScreenshotRequestProcessed().AddUObject(this, &USpudSubsystem::OnScreenshotRequestProcessed, UserIndex);
-				FScreenshotRequest::RequestScreenshot(false);
-				ScreenshotFileName = FScreenshotRequest::GetFilename();
-				float& ScreenShotTimeout = ScreenshotTimeouts.FindOrAdd(UserIndex);
-				ScreenShotTimeout = 1.0f;
-				return;
 			}
 		}
 
@@ -375,25 +387,14 @@ void USpudSubsystem::SaveGame(const FString& SlotName, const FText& Title, bool 
 	}
 }
 
-void USpudSubsystem::ScreenshotTimedOut(const int32 UserIndex)
+void USpudSubsystem::OnScreenshotCaptured(int32 Width, int32 Height, TArray<FColor>&& Colours, const int32 UserIndex)
 {
-	UE_LOG(LogSpudSubsystem, Error, TEXT("Request for save screenshot timed out. This is most likely a UE bug: "
-		"Widget Blueprints being open in the editor during PIE seems to break screenshots. Completing save game without a screenshot."))
-
-	ResetScreenshotState(UserIndex);
-	FinishSaveGame(SlotNameInProgress, UserIndex, TitleInProgress, ExtraInfoInProgress, nullptr);
-}
-
-void USpudSubsystem::OnScreenshotCaptured(int32 Width, int32 Height, const TArray<FColor>& Colours, const int32 UserIndex)
-{
-	ResetScreenshotState(UserIndex);
-
 	const int32 TargetWidth = ScreenshotWidth;
 	const int32 TargetHeight = ScreenshotHeight;
 	TWeakObjectPtr WeakThis(this);
 
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
-		[WeakThis, RawPixels = Colours, Width, Height, TargetWidth, TargetHeight, UserIndex]() mutable
+	AsyncTask(ENamedThreads::AnyBackgroundHiPriTask,
+		[WeakThis, RawPixels = MoveTemp(Colours), Width, Height, TargetWidth, TargetHeight, UserIndex]() mutable
 		{
 			TArray<FColor> CroppedResized;
 			FImageUtils::CropAndScaleImage(Width, Height, TargetWidth, TargetHeight, RawPixels, CroppedResized);
@@ -408,59 +409,9 @@ void USpudSubsystem::OnScreenshotCaptured(int32 Width, int32 Height, const TArra
 
 			AsyncTask(ENamedThreads::GameThread, [WeakThis, PngData, UserIndex]()
 			{
-				if (auto* S = WeakThis.Get())
+				if (const auto S = WeakThis.Get())
 				{
 					S->FinishSaveGame(S->SlotNameInProgress, UserIndex, S->TitleInProgress, S->ExtraInfoInProgress, &*PngData);
-				}
-			});
-		});
-}
-
-void USpudSubsystem::ResetScreenshotState(const int32 UserIndex)
-{
-	float& ScreenShotTimeout = ScreenshotTimeouts.FindOrAdd(UserIndex);
-	ScreenShotTimeout = 0.0f;
-
-	if (const auto PC = UGameplayStatics::GetPlayerController(GetWorld(), UserIndex))
-	{
-		if (const auto LP = PC->GetLocalPlayer())
-		{
-			if (const auto VC = LP->ViewportClient)
-			{
-				VC->OnScreenshotCaptured().Remove(OnScreenshotCapturedHandle);
-			}
-		}
-	}
-
-	FScreenshotRequest::OnScreenshotRequestProcessed().Remove(OnScreenshotRequestProcessedHandle);
-	OnScreenshotCapturedHandle.Reset();
-	OnScreenshotRequestProcessedHandle.Reset();
-}
-
-void USpudSubsystem::OnScreenshotRequestProcessed(const int32 UserIndex)
-{
-	ResetScreenshotState(UserIndex);
-
-	const FString FileName = ScreenshotFileName;
-	TWeakObjectPtr WeakThis(this);
-
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
-		[WeakThis, FileName, UserIndex]()
-		{
-			FImage Image;
-			FImageUtils::LoadImage(*FileName, Image);
-			IFileManager::Get().Delete(*FileName);
-			Image.ChangeFormat(ERawImageFormat::BGRA8, Image.GammaSpace);
-
-			const auto W = Image.GetWidth();
-			const auto H = Image.GetHeight();
-			TArray<FColor> Pixels(Image.AsBGRA8());
-
-			AsyncTask(ENamedThreads::GameThread, [WeakThis, Pixels = MoveTemp(Pixels), W, H, UserIndex]()
-			{
-				if (auto* S = WeakThis.Get())
-				{
-					S->OnScreenshotCaptured(W, H, Pixels, UserIndex);
 				}
 			});
 		});
@@ -513,12 +464,10 @@ void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserInd
 		TWeakObjectPtr WeakState(State);
 		TWeakObjectPtr WeakThis(this);
 		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
-			[WeakThis, WeakState, SaveSystem, SlotName, UserIndex]()
-			{
+			[WeakThis, WeakState, SaveSystem, SlotName, UserIndex]{
 				auto CompleteOnGameThread = [WeakThis, SlotName, UserIndex](bool bSuccess)
 				{
-					AsyncTask(ENamedThreads::GameThread, [WeakThis, SlotName, UserIndex, bSuccess]()
-	{
+					AsyncTask(ENamedThreads::GameThread, [WeakThis, SlotName, UserIndex, bSuccess]{
 						if (USpudSubsystem* S = WeakThis.Get())
 							S->SaveComplete(SlotName, UserIndex, bSuccess);
 					});
@@ -577,34 +526,34 @@ void USpudSubsystem::FinishSaveGame(const FString& SlotName, const int32 UserInd
 						});
 				});
 			});
+		}
+		else
+		{
+			TSharedRef<TArray<uint8>> OutSaveData(new TArray<uint8>());
+			auto Archive = FMemoryWriter(*OutSaveData, true);
+			State->SaveToArchive(Archive);
+			Archive.Close();
+
+			if (Archive.IsError() || Archive.IsCriticalError())
+			{
+				UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
+				SaveComplete(SlotName, UserIndex, false);
+			}
+			else if (OutSaveData->Num() > 0 && SlotName.Len() > 0)
+			{
+				bool SaveOK;
+				if (!SaveSystem->SaveGame(false, *SlotName, UserIndex, *OutSaveData))
+				{
+					UE_LOG(LogSpudSubsystem, Error, TEXT("Error while saving game to %s"), *SlotName);
+					SaveOK = false;
 				}
 				else
 				{
-		TSharedRef<TArray<uint8>> OutSaveData(new TArray<uint8>());
-		auto Archive = FMemoryWriter(*OutSaveData, true);
-		State->SaveToArchive(Archive);
-		Archive.Close();
-
-		if (Archive.IsError() || Archive.IsCriticalError())
-		{
-			UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
-			SaveComplete(SlotName, UserIndex, false);
-		}
-		else if (OutSaveData->Num() > 0 && SlotName.Len() > 0)
-		{
-					bool SaveOK;
-					if (!SaveSystem->SaveGame(false, *SlotName, UserIndex, *OutSaveData))
-					{
-						UE_LOG(LogSpudSubsystem, Error, TEXT("Error while saving game to %s"), *SlotName);
-						SaveOK = false;
-					}
-					else
-					{
-						UE_LOG(LogSpudSubsystem, Log, TEXT("Save to slot %s: Success"), *SlotName);
-						SaveOK = true;
-					}
-					SaveComplete(SlotName, UserIndex, SaveOK);
+					UE_LOG(LogSpudSubsystem, Log, TEXT("Save to slot %s: Success"), *SlotName);
+					SaveOK = true;
 				}
+				SaveComplete(SlotName, UserIndex, SaveOK);
+			}
 			else
 			{
 				UE_LOG(LogSpudSubsystem, Error, TEXT("Error while creating save game for slot %s"), *SlotName);
@@ -1642,24 +1591,6 @@ USpudCustomSaveInfo* USpudSubsystem::CreateCustomSaveInfo()
 
 void USpudSubsystem::Tick(float DeltaTime)
 {
-	TArray<int32> TimedOut;
-	for (TPair<int32, float>& ScreenShotTimeout : ScreenshotTimeouts)
-	{
-		if (ScreenShotTimeout.Value > 0)
-		{
-			ScreenShotTimeout.Value -= DeltaTime;
-			if (ScreenShotTimeout.Value <= 0)
-			{
-				ScreenShotTimeout.Value = 0;
-				TimedOut.Add(ScreenShotTimeout.Key);
-			}
-		}
-	}
-	for (const int32 Idx : TimedOut)
-	{
-		ScreenshotTimedOut(Idx);
-	}
-
 	if (bSupportWorldPartition)
 	{
 		auto world = GetWorld();

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -327,17 +327,21 @@ public:
 	* @param bTakeScreenshot If true, the save will include a screenshot, the dimensions of which are
 	* set by the ScreenshotWidth/ScreenshotHeight properties.
 	* @param ExtraInfo Optional object containing custom fields you want to be available when listing saves
+	* @param bAsync
 	**/
 	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly)
-    void AutoSaveGame(FText Title = FText(), bool bTakeScreenshot = true, const USpudCustomSaveInfo* ExtraInfo = nullptr, const int32 UserIndex = 0);
+    void AutoSaveGame(FText Title = FText(), bool bTakeScreenshot = true, const USpudCustomSaveInfo* ExtraInfo = nullptr, const int32 UserIndex = 0, bool
+                      bAsync = false);
 	/** Perform a Quick Save of the game in a single re-used slot, in response to a player request
 	 * @param Title Optional title of the save, if blank will be titled "Quick Save"
 	 * @param bTakeScreenshot If true, the save will include a screenshot, the dimensions of which are
 	 * set by the ScreenshotWidth/ScreenshotHeight properties.
 	 * @param ExtraInfo Optional object containing custom fields you want to be available when listing saves
+	 * @param bAsync
 	 **/
 	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly)
-    void QuickSaveGame(FText Title = FText(), bool bTakeScreenshot = true, const USpudCustomSaveInfo* ExtraInfo = nullptr, const int32 UserIndex = 0);
+    void QuickSaveGame(FText Title = FText(), bool bTakeScreenshot = true, const USpudCustomSaveInfo* ExtraInfo = nullptr, const int32 UserIndex = 0, bool
+                       bAsync = false);
 	
 	/**
 	 * Quick load the game from the last player-requested Quick Save slot (NOT the last autosave or manual save)

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -183,6 +183,9 @@ protected:
 	UPROPERTY()
 	TObjectPtr<const USpudCustomSaveInfo> ExtraInfoInProgress;
 
+	bool bPendingEndGame = false;
+	TOptional<TPair<bool, bool>> PendingNewGameArgs;
+
 	UPROPERTY()
 	TArray<TWeakObjectPtr<UObject>> GlobalObjects;
 	UPROPERTY()

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -149,6 +149,14 @@ public:
 	UPROPERTY(BlueprintReadWrite, Config)
 	int32 ScreenshotHeight = 135;
 
+	/// Maximum number of numbered quick save slots to keep. 0 = single reusable slot (legacy behavior).
+	UPROPERTY(BlueprintReadWrite, Config)
+	int32 MaxQuickSaves = 0;
+
+	/// Maximum number of numbered auto save slots to keep. 0 = single reusable slot (legacy behavior).
+	UPROPERTY(BlueprintReadWrite, Config)
+	int32 MaxAutoSaves = 0;
+
 	/// If true, use the show/hide events of streaming levels to save/load, which is compatible with World Partition
 	/// You can set this to false to change to the legacy mode which requires ASpudStreamingVolume
 	UPROPERTY(BlueprintReadWrite, Config)
@@ -261,6 +269,11 @@ protected:
 	void StoreLevel(ULevel* Level, bool bRelease, bool bBlocking);
 
 	void OnScreenshotCaptured(int32 Width, int32 Height, TArray<FColor>&& Colours, const int32 UserIndex);
+
+	static bool ParseNumberedSlotName(const FString& SlotName, const TCHAR* BaseSlotName, int32& OutNumber);
+	static FString MakeNumberedSlotName(const TCHAR* BaseSlotName, int32 Number);
+	int32 GetHighestSlotNumber(const TCHAR* BaseSlotName, const int32 UserIndex) const;
+	void CleanupOldNumberedSaves(const TCHAR* BaseSlotName, int32 MaxToKeep, int32 LatestNumber, const int32 UserIndex);
 
 	void FinishSaveGame(const FString& SlotName, const int32 UserIndex, const FText& Title, const USpudCustomSaveInfo* ExtraInfo, TArray<uint8>* ScreenshotData);
 	void LoadComplete(const FString& SlotName, const int32 UserIndex, bool bSuccess);

--- a/Source/SPUD/Public/SpudSubsystem.h
+++ b/Source/SPUD/Public/SpudSubsystem.h
@@ -149,11 +149,6 @@ public:
 	UPROPERTY(BlueprintReadWrite, Config)
 	int32 ScreenshotHeight = 135;
 
-	FDelegateHandle OnScreenshotCapturedHandle;
-	FDelegateHandle OnScreenshotRequestProcessedHandle;
-
-	FString ScreenshotFileName;
-
 	/// If true, use the show/hide events of streaming levels to save/load, which is compatible with World Partition
 	/// You can set this to false to change to the legacy mode which requires ASpudStreamingVolume
 	UPROPERTY(BlueprintReadWrite, Config)
@@ -177,7 +172,6 @@ protected:
 	FCriticalSection LevelsPendingLoadMutex;
 	FCriticalSection LevelsPendingUnloadMutex;
 	FTimerHandle StreamLevelUnloadTimerHandle;
-	TMap<int32, float> ScreenshotTimeouts;
 	FString SlotNameInProgress;
 	FText TitleInProgress;
 	UPROPERTY()
@@ -266,13 +260,7 @@ protected:
 	void StoreWorld(UWorld* World, bool bReleaseLevels, bool bBlocking);
 	void StoreLevel(ULevel* Level, bool bRelease, bool bBlocking);
 
-	UFUNCTION()
-	void ScreenshotTimedOut(const int32 UserIndex);
-	UFUNCTION()
-    void OnScreenshotCaptured(int32 Width, int32 Height, const TArray<FColor>& Colours, const int32 UserIndex);
-	UFUNCTION()
-    void OnScreenshotRequestProcessed(const int32 UserIndex);
-	void ResetScreenshotState(const int32 UserIndex);
+	void OnScreenshotCaptured(int32 Width, int32 Height, TArray<FColor>&& Colours, const int32 UserIndex);
 
 	void FinishSaveGame(const FString& SlotName, const int32 UserIndex, const FText& Title, const USpudCustomSaveInfo* ExtraInfo, TArray<uint8>* ScreenshotData);
 	void LoadComplete(const FString& SlotName, const int32 UserIndex, bool bSuccess);

--- a/Source/SPUD/SPUD.Build.cs
+++ b/Source/SPUD/SPUD.Build.cs
@@ -33,7 +33,6 @@ public class SPUD : ModuleRules
 			new string[]
 			{
 				"StructUtils",
-				"ImageCore",
 			}
 			);
 		


### PR DESCRIPTION
The changes address a few problems and add new features:

- Async flag was missing for both quick and autosaves, after adding the feature previosuly.
- There was a performance issue while visiting properties - the same classes were always visited entirely without caching the results, thus wasting time on discovering properties which were already discovered. Added caching.
- Fixed races with async saves and new/end game.
- Taking screenshots turned out to be a huge performance bottleneck. At 4k a screenshot could take up to 1.5s making a very noticeable hitch. Implemented a more efficient, although a bit manual, approach that bypasses the screenshot file system entirely. Moved heavy operations to async tasks.
- Added a feature for having several quick and auto saves with automatic cleanup. The default is the legacy behavior of having 1.